### PR TITLE
Edit sloppak files and add Keys arrangements from GP/MIDI

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -20,15 +20,31 @@ def setup(app, context):
     config_dir = context["config_dir"]
     get_dlc_dir = context["get_dlc_dir"]
 
-    from lib.song import load_song
+    from lib.song import load_song, arrangement_to_wire, arrangement_from_wire
     from lib.psarc import unpack_psarc
     from lib.patcher import pack_psarc
     from lib.audio import find_wem_files, convert_wem
+    from lib import sloppak as sloppak_mod
+    import json
+    import yaml
+    import zipfile
 
     STATIC_DIR = Path(__file__).resolve().parent.parent.parent / "static"
+    SLOPPAK_CACHE = STATIC_DIR / "sloppak_cache"
 
     # Active editing sessions: session_id -> {dir, audio_file, filename, song_data}
     sessions = {}
+
+    def _arrangement_id(name: str, used: set) -> str:
+        """Map an arrangement name to a stable filesystem-safe id, avoiding collisions."""
+        base = re.sub(r"[^a-z0-9_]", "", (name or "arr").lower().replace(" ", "_")) or "arr"
+        aid = base
+        i = 2
+        while aid in used:
+            aid = f"{base}{i}"
+            i += 1
+        used.add(aid)
+        return aid
 
     # ── List available CDLC files ────────────────────────────────────────
 
@@ -37,10 +53,15 @@ def setup(app, context):
         dlc_dir = get_dlc_dir()
         if not dlc_dir or not dlc_dir.exists():
             return []
-        files = sorted(
-            f.name for f in dlc_dir.iterdir()
-            if f.suffix == ".psarc" and f.is_file()
-        )
+        files = []
+        for f in dlc_dir.rglob("*"):
+            if not f.is_file():
+                continue
+            if f.suffix == ".psarc":
+                files.append({"filename": str(f.relative_to(dlc_dir)), "format": "psarc"})
+            elif f.suffix == ".sloppak":
+                files.append({"filename": str(f.relative_to(dlc_dir)), "format": "sloppak"})
+        files.sort(key=lambda x: x["filename"])
         return files
 
     # ── Load a CDLC for editing ──────────────────────────────────────────
@@ -56,7 +77,9 @@ def setup(app, context):
         if not filepath.exists():
             return JSONResponse({"error": "File not found"}, 404)
 
-        def _load():
+        is_sloppak = filepath.suffix == ".sloppak"
+
+        def _load_psarc():
             tmp_dir = tempfile.mkdtemp(prefix="slopsmith_editor_")
             try:
                 unpack_psarc(str(filepath), tmp_dir)
@@ -98,26 +121,85 @@ def setup(app, context):
                     continue
 
             result = _song_to_dict(song, audio_url)
-            return result, tmp_dir, audio_file, xml_files
+            result["format"] = "psarc"
+            return result, tmp_dir, audio_file, xml_files, None
+
+        def _load_sloppak():
+            SLOPPAK_CACHE.mkdir(parents=True, exist_ok=True)
+            loaded = sloppak_mod.load_song(filename, dlc_dir, SLOPPAK_CACHE)
+            song = loaded.song
+
+            # Build a per-arrangement id list from the manifest so we can map
+            # edits back to the correct JSON file on save.
+            arrangement_ids = []
+            for entry in (loaded.manifest.get("arrangements", []) or []):
+                arrangement_ids.append(entry.get("id", ""))
+
+            # Pick an audio URL: prefer the "full" stem, else the first stem.
+            audio_url = None
+            audio_file = None
+            stem_path = None
+            for s in loaded.stems:
+                if s.get("id") == "full":
+                    stem_path = loaded.source_dir / s.get("file", "")
+                    break
+            if stem_path is None and loaded.stems:
+                stem_path = loaded.source_dir / loaded.stems[0].get("file", "")
+            if stem_path and stem_path.exists():
+                audio_id = Path(filename).stem.replace(" ", "_").replace("/", "_")
+                ext = stem_path.suffix
+                dest = STATIC_DIR / f"editor_audio_{audio_id}{ext}"
+                shutil.copy2(stem_path, dest)
+                audio_url = f"/static/editor_audio_{audio_id}{ext}"
+                audio_file = str(stem_path)
+
+            result = _song_to_dict(song, audio_url)
+            result["format"] = "sloppak"
+            # Carry the manifest-derived arrangement id list onto each
+            # arrangement so the frontend can round-trip it back to us.
+            for i, arr_data in enumerate(result.get("arrangements", [])):
+                arr_data["id"] = arrangement_ids[i] if i < len(arrangement_ids) else _arrangement_id(arr_data["name"], set())
+
+            return (
+                result,
+                str(loaded.source_dir),  # working dir = the unpacked sloppak cache
+                audio_file,
+                None,                    # no xml_files for sloppak
+                {
+                    "manifest": loaded.manifest,
+                    "arrangement_ids": arrangement_ids,
+                },
+            )
 
         try:
-            result, session_dir, audio_file, xml_files = (
-                await asyncio.get_event_loop().run_in_executor(None, _load)
-            )
+            if is_sloppak:
+                result, session_dir, audio_file, xml_files, sloppak_state = (
+                    await asyncio.get_event_loop().run_in_executor(None, _load_sloppak)
+                )
+            else:
+                result, session_dir, audio_file, xml_files, sloppak_state = (
+                    await asyncio.get_event_loop().run_in_executor(None, _load_psarc)
+                )
         except Exception as e:
+            import traceback
+            traceback.print_exc()
             return JSONResponse({"error": str(e)}, 500)
 
         session_id = Path(filename).stem
-        # Clean up previous session for same file
+        # Clean up previous PSARC session for same file (sloppak sessions
+        # use the cache dir directly — never delete it on session swap).
         if session_id in sessions:
             old = sessions[session_id]
-            shutil.rmtree(old["dir"], ignore_errors=True)
+            if old.get("format") == "psarc":
+                shutil.rmtree(old["dir"], ignore_errors=True)
 
         sessions[session_id] = {
             "dir": session_dir,
             "audio_file": audio_file,
             "filename": filename,
             "xml_files": xml_files,
+            "format": "sloppak" if is_sloppak else "psarc",
+            "sloppak_state": sloppak_state,
         }
         result["session_id"] = session_id
         return result
@@ -139,7 +221,12 @@ def setup(app, context):
         sections = data.get("sections", [])
         metadata = data.get("metadata", {})
 
-        def _save():
+        # Sloppak save can be a full snapshot of all arrangements (needed when
+        # arrangements were added). If arrangements isn't provided, save_cdlc
+        # only updates the single arrangement at arrangement_index.
+        all_arrangements = data.get("arrangements")
+
+        def _save_psarc():
             xml_files = session["xml_files"]
             if arrangement_index >= len(xml_files):
                 raise RuntimeError("Invalid arrangement index")
@@ -174,8 +261,174 @@ def setup(app, context):
             pack_psarc(session["dir"], str(output_path))
             return str(output_path)
 
+        def _save_sloppak():
+            sloppak_state = session.get("sloppak_state") or {}
+            manifest = dict(sloppak_state.get("manifest") or {})
+            existing_ids = list(sloppak_state.get("arrangement_ids") or [])
+            source_dir = Path(session["dir"])
+            dlc_dir = get_dlc_dir()
+            filename = session["filename"]
+            output_path = dlc_dir / filename
+
+            # Determine the arrangement set to write. If `arrangements` was
+            # provided, it's the authoritative full snapshot (handles adds
+            # and reorders). Otherwise we update only the single arrangement
+            # at arrangement_index using notes/chords/chord_templates.
+            if all_arrangements is None:
+                if arrangement_index >= len(existing_ids):
+                    raise RuntimeError("Invalid arrangement index")
+                # Fetch the current manifest entry for the edited arrangement
+                # so we keep its name/tuning/capo.
+                old_entries = manifest.get("arrangements", []) or []
+                if arrangement_index >= len(old_entries):
+                    raise RuntimeError("Manifest arrangement out of range")
+                old_entry = old_entries[arrangement_index]
+                merged_arrangements = []
+                # We need to reconstruct the wire data for the edited
+                # arrangement only; other arrangements stay untouched.
+                for i, entry in enumerate(old_entries):
+                    if i == arrangement_index:
+                        wire = _arr_dict_to_wire(
+                            entry.get("name", ""),
+                            entry.get("tuning", [0]*6),
+                            int(entry.get("capo", 0)),
+                            notes, chords, chord_templates,
+                        )
+                        # First arrangement carries beats/sections.
+                        if i == 0:
+                            wire["beats"] = [
+                                {"time": round(float(b.get("time", 0)), 3),
+                                 "measure": int(b.get("measure", -1))}
+                                for b in beats
+                            ]
+                            wire["sections"] = [
+                                {"name": s.get("name", ""),
+                                 "number": int(s.get("number", 0)),
+                                 "time": round(float(s.get("start_time", 0)), 3)}
+                                for s in sections
+                            ]
+                        merged_arrangements.append({
+                            "entry": entry,
+                            "wire": wire,
+                        })
+                    else:
+                        merged_arrangements.append({"entry": entry, "wire": None})
+            else:
+                # Full snapshot path — used when arrangements were added/removed
+                # or for safety on every save.
+                used_ids: set = set()
+                merged_arrangements = []
+                first = True
+                for i, ad in enumerate(all_arrangements):
+                    aid = ad.get("id") or _arrangement_id(ad.get("name", "arr"), used_ids)
+                    used_ids.add(aid)
+                    wire = _arr_dict_to_wire(
+                        ad.get("name", "arr"),
+                        ad.get("tuning", [0]*6),
+                        int(ad.get("capo", 0)),
+                        ad.get("notes", []),
+                        ad.get("chords", []),
+                        ad.get("chord_templates", []),
+                    )
+                    if first:
+                        wire["beats"] = [
+                            {"time": round(float(b.get("time", 0)), 3),
+                             "measure": int(b.get("measure", -1))}
+                            for b in beats
+                        ]
+                        wire["sections"] = [
+                            {"name": s.get("name", ""),
+                             "number": int(s.get("number", 0)),
+                             "time": round(float(s.get("start_time", 0)), 3)}
+                            for s in sections
+                        ]
+                        first = False
+                    merged_arrangements.append({
+                        "entry": {
+                            "id": aid,
+                            "name": ad.get("name", "arr"),
+                            "file": f"arrangements/{aid}.json",
+                            "tuning": list(ad.get("tuning", [0]*6)),
+                            "capo": int(ad.get("capo", 0)),
+                        },
+                        "wire": wire,
+                    })
+
+            # Write/update arrangement JSON files inside source_dir
+            arr_dir = source_dir / "arrangements"
+            arr_dir.mkdir(parents=True, exist_ok=True)
+            new_manifest_arrangements = []
+            kept_paths: set[Path] = set()
+            for item in merged_arrangements:
+                entry = item["entry"]
+                wire = item["wire"]
+                if wire is not None:
+                    # Determine target path — fall back to default if missing
+                    rel = entry.get("file") or f"arrangements/{entry.get('id', 'arr')}.json"
+                    arr_path = source_dir / rel
+                    arr_path.parent.mkdir(parents=True, exist_ok=True)
+                    arr_path.write_text(
+                        json.dumps(wire, separators=(",", ":")),
+                        encoding="utf-8",
+                    )
+                    entry = dict(entry)
+                    entry["file"] = rel
+                # Track every kept arrangement file (rewritten or untouched)
+                rel = entry.get("file")
+                if rel:
+                    kept_paths.add((source_dir / rel).resolve())
+                new_manifest_arrangements.append(entry)
+            manifest["arrangements"] = new_manifest_arrangements
+
+            # Drop orphaned arrangement JSONs (e.g. after a remove). Only
+            # touches files inside the arrangements/ subdir to be safe.
+            if arr_dir.exists():
+                for f in arr_dir.glob("*.json"):
+                    if f.resolve() not in kept_paths:
+                        try:
+                            f.unlink()
+                        except OSError:
+                            pass
+
+            # Apply edited top-level metadata (title/artist/album/year only —
+            # don't let the editor overwrite stems/lyrics/cover paths).
+            if metadata:
+                for k in ("title", "artist", "album"):
+                    if metadata.get(k) is not None:
+                        manifest[k] = metadata[k]
+                if metadata.get("year") is not None:
+                    try:
+                        manifest["year"] = int(metadata["year"])
+                    except (TypeError, ValueError):
+                        pass
+
+            # Write manifest.yaml back into the source dir
+            (source_dir / "manifest.yaml").write_text(
+                yaml.safe_dump(manifest, sort_keys=False, allow_unicode=True),
+                encoding="utf-8",
+            )
+
+            # Backup original .sloppak (zip) if not already
+            if output_path.exists():
+                backup = dlc_dir / (filename + ".bak")
+                if not backup.exists():
+                    shutil.copy2(output_path, backup)
+
+            # Re-zip the source dir into the .sloppak file
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            tmp_zip = output_path.with_suffix(output_path.suffix + ".tmp")
+            with zipfile.ZipFile(str(tmp_zip), "w", zipfile.ZIP_DEFLATED) as zf:
+                for f in source_dir.rglob("*"):
+                    if f.is_file():
+                        zf.write(f, f.relative_to(source_dir).as_posix())
+            tmp_zip.replace(output_path)
+            return str(output_path)
+
         try:
-            output = await asyncio.get_event_loop().run_in_executor(None, _save)
+            if session.get("format") == "sloppak":
+                output = await asyncio.get_event_loop().run_in_executor(None, _save_sloppak)
+            else:
+                output = await asyncio.get_event_loop().run_in_executor(None, _save_psarc)
         except Exception as e:
             import traceback
             traceback.print_exc()
@@ -284,6 +537,93 @@ def setup(app, context):
             return JSONResponse({"error": f"Failed to parse GP file: {e}"}, 500)
 
         return {"gp_path": gp_path, "tracks": tracks}
+
+    # ── MIDI import: list tracks ─────────────────────────────────────
+
+    @app.post("/api/plugins/editor/import-midi")
+    async def import_midi(file: UploadFile = File(...)):
+        """Upload a MIDI file and return track listing."""
+        from lib.midi_import import list_midi_tracks
+
+        suffix = Path(file.filename or "song.mid").suffix or ".mid"
+        tmp = tempfile.mkdtemp(prefix="slopsmith_midi_")
+        midi_path = os.path.join(tmp, "upload" + suffix)
+        content = await file.read()
+        Path(midi_path).write_bytes(content)
+
+        def _list():
+            return list_midi_tracks(midi_path)
+
+        try:
+            tracks = await asyncio.get_event_loop().run_in_executor(None, _list)
+        except Exception as e:
+            shutil.rmtree(tmp, ignore_errors=True)
+            return JSONResponse({"error": f"Failed to parse MIDI file: {e}"}, 500)
+
+        return {"midi_path": midi_path, "tracks": tracks}
+
+    # ── MIDI import: convert a track to a Keys arrangement ────────────
+
+    @app.post("/api/plugins/editor/import-keys-midi")
+    async def import_keys_midi(data: dict):
+        """Convert a MIDI track into a Keys arrangement (editor-ready dict)."""
+        from lib.midi_import import convert_midi_track_to_keys_wire
+
+        midi_path = data.get("midi_path", "")
+        track_index = data.get("track_index")
+        audio_offset = float(data.get("audio_offset", 0.0))
+
+        if not midi_path or not Path(midi_path).exists():
+            return JSONResponse({"error": "MIDI file not found"}, 400)
+        if track_index is None:
+            return JSONResponse({"error": "track_index required"}, 400)
+
+        def _convert():
+            wire = convert_midi_track_to_keys_wire(
+                midi_path, int(track_index), audio_offset, "Keys"
+            )
+            # Convert wire → editor's long-named shape so the frontend can
+            # consume it identically to import-keys output.
+            arr_data = {
+                "name": wire["name"],
+                "tuning": wire["tuning"],
+                "capo": wire["capo"],
+                "notes": [],
+                "chords": [],
+                "chord_templates": [],
+            }
+            for n in wire["notes"]:
+                arr_data["notes"].append({
+                    "time": n["t"],
+                    "string": n["s"],
+                    "fret": n["f"],
+                    "sustain": n["sus"],
+                    "techniques": {
+                        "bend": n.get("bn", 0),
+                        "slide_to": n.get("sl", -1),
+                        "slide_unpitch_to": n.get("slu", -1),
+                        "hammer_on": n.get("ho", False),
+                        "pull_off": n.get("po", False),
+                        "harmonic": n.get("hm", False),
+                        "harmonic_pinch": n.get("hp", False),
+                        "palm_mute": n.get("pm", False),
+                        "mute": n.get("mt", False),
+                        "tremolo": n.get("tr", False),
+                        "accent": n.get("ac", False),
+                        "tap": n.get("tp", False),
+                        "link_next": False,
+                    },
+                })
+            return arr_data
+
+        try:
+            arr_data = await asyncio.get_event_loop().run_in_executor(None, _convert)
+        except Exception as e:
+            import traceback
+            traceback.print_exc()
+            return JSONResponse({"error": str(e)}, 500)
+
+        return {"arrangement": arr_data}
 
     # ── Convert GP tracks to arrangement and open in editor ──────────
 
@@ -529,6 +869,151 @@ def setup(app, context):
 
         return {"arrangement": arr_data, "tmp_dir": tmp_dir, "xml_path": xml_path}
 
+    # ── Import drum/percussion tracks from a GP file ─────────────────
+
+    @app.post("/api/plugins/editor/import-drums")
+    async def import_drums_track(data: dict):
+        """Import a drum/percussion track from a GP file and return as an arrangement."""
+        from lib.gp2rs import (
+            list_tracks, convert_drum_track, is_drum_track,
+            _build_tempo_map, _tick_to_seconds, GP_TICKS_PER_QUARTER,
+        )
+        from lib.song import parse_arrangement, Song, Beat, Section
+        import guitarpro
+
+        gp_path = data.get("gp_path", "")
+        track_index = data.get("track_index")
+        audio_offset = data.get("audio_offset", 0.0)
+
+        if not gp_path or not Path(gp_path).exists():
+            return JSONResponse({"error": "GP file not found"}, 400)
+        if track_index is None:
+            return JSONResponse({"error": "track_index required"}, 400)
+
+        def _convert():
+            song = guitarpro.parse(gp_path)
+
+            xml_str = convert_drum_track(
+                song, track_index, audio_offset, "Drums"
+            )
+
+            # Write to temp file so we can parse it back
+            tmp = tempfile.mkdtemp(prefix="slopsmith_drums_")
+            xml_path = os.path.join(tmp, "Drums.xml")
+            Path(xml_path).write_text(xml_str)
+
+            arr = parse_arrangement(xml_path)
+            arr_data = {
+                "name": "Drums",
+                "tuning": arr.tuning,
+                "capo": arr.capo,
+                "notes": [],
+                "chords": [],
+                "chord_templates": [],
+            }
+
+            for n in arr.notes:
+                arr_data["notes"].append({
+                    "time": round(n.time, 3),
+                    "string": n.string,
+                    "fret": n.fret,
+                    "sustain": round(n.sustain, 3),
+                    "techniques": {
+                        "bend": n.bend,
+                        "slide_to": n.slide_to,
+                        "slide_unpitch_to": n.slide_unpitch_to,
+                        "hammer_on": n.hammer_on,
+                        "pull_off": n.pull_off,
+                        "harmonic": n.harmonic,
+                        "harmonic_pinch": n.harmonic_pinch,
+                        "palm_mute": n.palm_mute,
+                        "mute": n.mute,
+                        "tremolo": n.tremolo,
+                        "accent": n.accent,
+                        "tap": n.tap,
+                        "link_next": n.link_next,
+                    },
+                })
+
+            for ch in arr.chords:
+                chord_data = {
+                    "time": round(ch.time, 3),
+                    "chord_id": ch.chord_id,
+                    "high_density": ch.high_density,
+                    "notes": [],
+                }
+                for cn in ch.notes:
+                    chord_data["notes"].append({
+                        "time": round(cn.time, 3),
+                        "string": cn.string,
+                        "fret": cn.fret,
+                        "sustain": round(cn.sustain, 3),
+                        "techniques": {
+                            "bend": cn.bend,
+                            "slide_to": cn.slide_to,
+                            "slide_unpitch_to": cn.slide_unpitch_to,
+                            "hammer_on": cn.hammer_on,
+                            "pull_off": cn.pull_off,
+                            "harmonic": cn.harmonic,
+                            "palm_mute": cn.palm_mute,
+                            "mute": cn.mute,
+                            "tremolo": cn.tremolo,
+                            "accent": cn.accent,
+                            "tap": cn.tap,
+                            "link_next": cn.link_next,
+                        },
+                    })
+                arr_data["chords"].append(chord_data)
+
+            for ct in arr.chord_templates:
+                arr_data["chord_templates"].append({
+                    "name": ct.name,
+                    "frets": ct.frets,
+                    "fingers": ct.fingers,
+                })
+
+            return arr_data, tmp, xml_path
+
+        try:
+            arr_data, tmp_dir, xml_path = (
+                await asyncio.get_event_loop().run_in_executor(None, _convert)
+            )
+        except Exception as e:
+            import traceback
+            traceback.print_exc()
+            return JSONResponse({"error": str(e)}, 500)
+
+        return {"arrangement": arr_data, "tmp_dir": tmp_dir, "xml_path": xml_path}
+
+    # ── Remove arrangement from session ────────────────────────────
+
+    @app.post("/api/plugins/editor/remove-arrangement")
+    async def remove_arrangement(data: dict):
+        """Remove an arrangement from the current editing session."""
+        session_id = data.get("session_id", "")
+        session = sessions.get(session_id)
+        if not session:
+            return JSONResponse({"error": "No active session"}, 400)
+
+        idx = data.get("arrangement_index", -1)
+
+        # Sloppak: nothing to remove server-side until save. The frontend
+        # splices its in-memory arrangements and the next save rewrites
+        # the manifest + drops the orphaned arrangement JSON.
+        if session.get("format") == "sloppak":
+            return {"success": True, "arrangement_count": -1, "format": "sloppak"}
+
+        xml_files = session.get("xml_files") or []
+        if 0 <= idx < len(xml_files):
+            removed = xml_files.pop(idx)
+            # Delete the XML file
+            try:
+                Path(removed).unlink(missing_ok=True)
+            except Exception:
+                pass
+
+        return {"success": True, "arrangement_count": len(xml_files)}
+
     # ── Add arrangement to existing session ──────────────────────────
 
     @app.post("/api/plugins/editor/add-arrangement")
@@ -545,7 +1030,14 @@ def setup(app, context):
         if not arrangement:
             return JSONResponse({"error": "arrangement data required"}, 400)
 
-        # If we have an XML path from import-keys, add it to session's xml_files
+        # Sloppak sessions don't use XML on disk — the save endpoint writes
+        # arrangement JSON files when the user commits. The frontend keeps
+        # the new arrangement in S.arrangements and sends the full snapshot
+        # at save time.
+        if session.get("format") == "sloppak":
+            return {"success": True, "arrangement_count": -1, "format": "sloppak"}
+
+        # PSARC path: persist the XML so save can use the existing flow.
         if xml_path and Path(xml_path).exists():
             # Copy XML into session dir
             dest = os.path.join(session["dir"], f"Keys_{len(session.get('xml_files', []))}.xml")
@@ -654,6 +1146,67 @@ def setup(app, context):
         return {"success": True, "path": output_path}
 
     # ── Helpers ──────────────────────────────────────────────────────────
+
+    def _arr_dict_to_wire(name, tuning, capo, notes, chords, chord_templates):
+        """Convert editor's long-named arrangement dict into sloppak wire format.
+
+        Editor uses {time, string, fret, sustain, techniques: {bend, slide_to,
+        ...}}; the wire format uses {t, s, f, sus, sl, bn, ho, ...}.
+        """
+        def _note(n):
+            tech = n.get("techniques", {}) or {}
+            out = {
+                "t": round(float(n.get("time", 0)), 3),
+                "s": int(n.get("string", 0)),
+                "f": int(n.get("fret", 0)),
+                "sus": round(float(n.get("sustain", 0)), 3),
+                "sl": int(tech.get("slide_to", -1)),
+                "slu": int(tech.get("slide_unpitch_to", -1)),
+                "bn": round(float(tech.get("bend", 0) or 0), 1),
+                "ho": bool(tech.get("hammer_on", False)),
+                "po": bool(tech.get("pull_off", False)),
+                "hm": bool(tech.get("harmonic", False)),
+                "hp": bool(tech.get("harmonic_pinch", False)),
+                "pm": bool(tech.get("palm_mute", False)),
+                "mt": bool(tech.get("mute", False)),
+                "tr": bool(tech.get("tremolo", False)),
+                "ac": bool(tech.get("accent", False)),
+                "tp": bool(tech.get("tap", False)),
+            }
+            return out
+
+        def _note_in_chord(n):
+            # Chord-member notes share the chord's time, so we omit `t`.
+            d = _note(n)
+            d.pop("t", None)
+            return d
+
+        wire = {
+            "name": name,
+            "tuning": list(tuning),
+            "capo": int(capo),
+            "notes": [_note(n) for n in notes],
+            "chords": [
+                {
+                    "t": round(float(c.get("time", 0)), 3),
+                    "id": int(c.get("chord_id", -1)),
+                    "hd": bool(c.get("high_density", False)),
+                    "notes": [_note_in_chord(cn) for cn in c.get("notes", [])],
+                }
+                for c in chords
+            ],
+            "anchors": [],
+            "handshapes": [],
+            "templates": [
+                {
+                    "name": ct.get("name", ""),
+                    "fingers": list(ct.get("fingers", [-1]*6)),
+                    "frets": list(ct.get("frets", [-1]*6)),
+                }
+                for ct in chord_templates
+            ],
+        }
+        return wire
 
     def _song_to_dict(song, audio_url):
         """Convert a Song object to JSON-serializable dict."""

--- a/routes.py
+++ b/routes.py
@@ -494,8 +494,12 @@ def setup(app, context):
                 used_ids: set = set()
                 merged_arrangements = []
                 for i, ad in enumerate(all_arrangements):
-                    aid = ad.get("id") or _arrangement_id(ad.get("name", "arr"), used_ids)
-                    used_ids.add(aid)
+                    raw_id = ad.get("id") or ""
+                    if raw_id and raw_id not in used_ids:
+                        aid = raw_id
+                        used_ids.add(aid)
+                    else:
+                        aid = _arrangement_id(ad.get("name", "arr"), used_ids)
                     wire = _build_wire(ad, i == 0)
                     merged_arrangements.append({
                         "entry": {
@@ -774,10 +778,14 @@ def setup(app, context):
         midi_path = str(validated)
         if track_index is None:
             return JSONResponse({"error": "track_index required"}, 400)
+        try:
+            track_index = int(track_index)
+        except (TypeError, ValueError):
+            return JSONResponse({"error": "track_index must be an integer"}, 400)
 
         def _convert():
             wire = convert_midi_track_to_keys_wire(
-                midi_path, int(track_index), audio_offset, "Keys",
+                midi_path, track_index, audio_offset, "Keys",
                 channel_filter=channel_filter,
             )
             # Convert wire → editor's long-named shape so the frontend can
@@ -981,6 +989,10 @@ def setup(app, context):
         gp_path = str(validated)
         if track_index is None:
             return JSONResponse({"error": "track_index required"}, 400)
+        try:
+            track_index = int(track_index)
+        except (TypeError, ValueError):
+            return JSONResponse({"error": "track_index must be an integer"}, 400)
 
         def _convert():
             song = guitarpro.parse(gp_path)
@@ -1107,6 +1119,10 @@ def setup(app, context):
         gp_path = str(validated)
         if track_index is None:
             return JSONResponse({"error": "track_index required"}, 400)
+        try:
+            track_index = int(track_index)
+        except (TypeError, ValueError):
+            return JSONResponse({"error": "track_index must be an integer"}, 400)
 
         def _convert():
             song = guitarpro.parse(gp_path)

--- a/routes.py
+++ b/routes.py
@@ -345,11 +345,14 @@ def setup(app, context):
         if not session:
             return JSONResponse({"error": "No active session"}, 400)
 
-        raw_arr_idx = data.get("arrangement_index", 0)
-        try:
-            arrangement_index = int(raw_arr_idx)
-        except (TypeError, ValueError):
-            return JSONResponse({"error": "arrangement_index must be an integer"}, 400)
+        raw_arr_idx = data.get("arrangement_index")
+        if raw_arr_idx is None:
+            arrangement_index = 0
+        else:
+            try:
+                arrangement_index = int(raw_arr_idx)
+            except (TypeError, ValueError):
+                return JSONResponse({"error": "arrangement_index must be an integer"}, 400)
         notes = data.get("notes", [])
         chords = data.get("chords", [])
         chord_templates = data.get("chord_templates", [])
@@ -1233,11 +1236,14 @@ def setup(app, context):
         if not session:
             return JSONResponse({"error": "No active session"}, 400)
 
-        raw_idx = data.get("arrangement_index", -1)
-        try:
-            idx = int(raw_idx)
-        except (TypeError, ValueError):
-            return JSONResponse({"error": "arrangement_index must be an integer"}, 400)
+        raw_idx = data.get("arrangement_index")
+        if raw_idx is None:
+            idx = -1
+        else:
+            try:
+                idx = int(raw_idx)
+            except (TypeError, ValueError):
+                return JSONResponse({"error": "arrangement_index must be an integer"}, 400)
 
         # Sloppak: nothing to remove server-side until save. The frontend
         # splices its in-memory arrangements and the next save rewrites

--- a/routes.py
+++ b/routes.py
@@ -7,6 +7,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+import time
 import zipfile
 from pathlib import Path
 from xml.etree import ElementTree as ET
@@ -714,13 +715,12 @@ def setup(app, context):
         # Opportunistic TTL cleanup: remove any slopsmith_midi_* sandbox dirs
         # older than 30 minutes so unclaimed uploads (cancelled modals, etc.)
         # don't accumulate indefinitely on the server.
-        import time as _time
         _ttl_secs = 30 * 60
-        _tmp_root = Path(tempfile.gettempdir())
-        for _stale in _tmp_root.glob("slopsmith_midi_*"):
+        tmp_root = Path(tempfile.gettempdir())
+        for _stale in tmp_root.glob("slopsmith_midi_*"):
             try:
                 if _stale.is_dir():
-                    age = _time.time() - _stale.stat().st_mtime
+                    age = time.time() - _stale.stat().st_mtime
                     if age > _ttl_secs:
                         shutil.rmtree(_stale, ignore_errors=True)
             except OSError:

--- a/routes.py
+++ b/routes.py
@@ -1,11 +1,13 @@
 """Arrangement Editor plugin — backend routes."""
 
 import asyncio
+import json
 import os
 import re
 import shutil
 import subprocess
 import tempfile
+import zipfile
 from pathlib import Path
 from xml.etree import ElementTree as ET
 from xml.dom import minidom
@@ -15,19 +17,18 @@ import base64
 from fastapi import UploadFile, File, Form
 from fastapi.responses import FileResponse, JSONResponse
 
+import yaml
+
 
 def setup(app, context):
     config_dir = context["config_dir"]
     get_dlc_dir = context["get_dlc_dir"]
 
-    from lib.song import load_song, arrangement_to_wire, arrangement_from_wire
+    from lib.song import load_song, phrase_to_wire
     from lib.psarc import unpack_psarc
     from lib.patcher import pack_psarc
     from lib.audio import find_wem_files, convert_wem
     from lib import sloppak as sloppak_mod
-    import json
-    import yaml
-    import zipfile
 
     STATIC_DIR = Path(__file__).resolve().parent.parent.parent / "static"
     SLOPPAK_CACHE = STATIC_DIR / "sloppak_cache"
@@ -36,7 +37,8 @@ def setup(app, context):
     sessions = {}
 
     def _arrangement_id(name: str, used: set) -> str:
-        """Map an arrangement name to a stable filesystem-safe id, avoiding collisions."""
+        """Map an arrangement name to a stable filesystem-safe id, avoiding
+        collisions (suffix counter starts at 2: bass, bass2, bass3, ...)."""
         base = re.sub(r"[^a-z0-9_]", "", (name or "arr").lower().replace(" ", "_")) or "arr"
         aid = base
         i = 2
@@ -45,6 +47,32 @@ def setup(app, context):
             i += 1
         used.add(aid)
         return aid
+
+    def _validate_editor_upload_path(path_str: str, prefix: str) -> Path | None:
+        """Resolve a client-supplied upload path and constrain it to the
+        editor's tempfile.mkdtemp(prefix=...) sandbox. Returns the resolved
+        path on success, or None if the path escapes the sandbox or doesn't
+        exist. Defends against import-keys / import-drums / import-keys-midi
+        being pointed at arbitrary readable files via the request body.
+        """
+        if not path_str:
+            return None
+        try:
+            resolved = Path(path_str).resolve()
+        except Exception:
+            return None
+        if not resolved.exists():
+            return None
+        tmp_root = Path(tempfile.gettempdir()).resolve()
+        try:
+            rel = resolved.relative_to(tmp_root)
+        except ValueError:
+            return None
+        # First component should be the mkdtemp dir whose name starts
+        # with our prefix (e.g. slopsmith_gp_XXXX).
+        if not rel.parts or not rel.parts[0].startswith(prefix):
+            return None
+        return resolved
 
     # ── List available CDLC files ────────────────────────────────────────
 
@@ -73,7 +101,18 @@ def setup(app, context):
             return JSONResponse({"error": "No filename"}, 400)
 
         dlc_dir = get_dlc_dir()
-        filepath = dlc_dir / filename
+        if not dlc_dir:
+            return JSONResponse({"error": "DLC folder not configured"}, 400)
+        filepath = (dlc_dir / filename).resolve()
+        # Constrain client-supplied filename to dlc_dir — defends against
+        # `../` traversal and absolute paths now that filename can include
+        # subdirectories.
+        try:
+            filepath.relative_to(dlc_dir.resolve())
+        except ValueError:
+            return JSONResponse({"error": "Invalid filename"}, 400)
+        if filepath.suffix not in (".psarc", ".sloppak"):
+            return JSONResponse({"error": "Unsupported file type"}, 400)
         if not filepath.exists():
             return JSONResponse({"error": "File not found"}, 404)
 
@@ -128,6 +167,11 @@ def setup(app, context):
             SLOPPAK_CACHE.mkdir(parents=True, exist_ok=True)
             loaded = sloppak_mod.load_song(filename, dlc_dir, SLOPPAK_CACHE)
             song = loaded.song
+            # Distinguish authoring (directory) form from distribution (zip)
+            # form so save knows whether to re-zip. With dir-form, source_dir
+            # *is* the original sloppak dir; rewriting the manifest +
+            # arrangement files in place is the whole save.
+            sloppak_form = "dir" if filepath.is_dir() else "zip"
 
             # Build a per-arrangement id list from the manifest so we can map
             # edits back to the correct JSON file on save.
@@ -157,8 +201,30 @@ def setup(app, context):
             result["format"] = "sloppak"
             # Carry the manifest-derived arrangement id list onto each
             # arrangement so the frontend can round-trip it back to us.
+            # Use a single `used_ids` set when generating fallback ids so two
+            # nameless arrangements don't both end up as "arr".
+            used_ids: set = {aid for aid in arrangement_ids if aid}
             for i, arr_data in enumerate(result.get("arrangements", [])):
-                arr_data["id"] = arrangement_ids[i] if i < len(arrangement_ids) else _arrangement_id(arr_data["name"], set())
+                aid = arrangement_ids[i] if i < len(arrangement_ids) else ""
+                if not aid:
+                    aid = _arrangement_id(arr_data["name"], used_ids)
+                arr_data["id"] = aid
+
+            # Round-trip-preserve the arrangement-level arrays the editor UI
+            # doesn't expose: anchors, handshapes, phrases. The save path
+            # passes them straight through so the next save doesn't drop them.
+            for i, arr in enumerate(song.arrangements):
+                arr_data = result["arrangements"][i]
+                arr_data["anchors"] = [
+                    {"time": a.time, "fret": a.fret, "width": a.width}
+                    for a in (arr.anchors or [])
+                ]
+                arr_data["handshapes"] = [
+                    {"chord_id": h.chord_id, "start_time": h.start_time, "end_time": h.end_time}
+                    for h in (arr.hand_shapes or [])
+                ]
+                if arr.phrases:
+                    arr_data["phrases"] = [phrase_to_wire(p) for p in arr.phrases]
 
             return (
                 result,
@@ -168,6 +234,8 @@ def setup(app, context):
                 {
                     "manifest": loaded.manifest,
                     "arrangement_ids": arrangement_ids,
+                    "form": sloppak_form,
+                    "original_path": str(filepath),
                 },
             )
 
@@ -243,7 +311,7 @@ def setup(app, context):
             )
 
             # Write XML
-            Path(xml_path).write_text(xml_str)
+            Path(xml_path).write_text(xml_str, encoding="utf-8")
 
             # Try to compile XML -> SNG
             _compile_sng(xml_path)
@@ -264,85 +332,80 @@ def setup(app, context):
         def _save_sloppak():
             sloppak_state = session.get("sloppak_state") or {}
             manifest = dict(sloppak_state.get("manifest") or {})
-            existing_ids = list(sloppak_state.get("arrangement_ids") or [])
-            source_dir = Path(session["dir"])
+            sloppak_form = sloppak_state.get("form") or "zip"
+            source_dir = Path(session["dir"]).resolve()
             dlc_dir = get_dlc_dir()
             filename = session["filename"]
-            output_path = dlc_dir / filename
+            output_path = (dlc_dir / filename).resolve()
+
+            # Build the wire JSON for one arrangement, preserving anchors,
+            # handshapes, and phrases from the loaded session (the editor
+            # UI doesn't expose them yet — pass them through verbatim).
+            def _build_wire(arr_dict, is_first):
+                wire = _arr_dict_to_wire(
+                    arr_dict.get("name", "arr"),
+                    arr_dict.get("tuning", [0]*6),
+                    int(arr_dict.get("capo", 0)),
+                    arr_dict.get("notes", []),
+                    arr_dict.get("chords", []),
+                    arr_dict.get("chord_templates", []),
+                )
+                wire["anchors"] = list(arr_dict.get("anchors") or [])
+                wire["handshapes"] = list(arr_dict.get("handshapes") or [])
+                ph = arr_dict.get("phrases")
+                if ph:
+                    wire["phrases"] = list(ph)
+                if is_first:
+                    wire["beats"] = [
+                        {"time": round(float(b.get("time", 0)), 3),
+                         "measure": int(b.get("measure", -1))}
+                        for b in beats
+                    ]
+                    wire["sections"] = [
+                        {"name": s.get("name", ""),
+                         "number": int(s.get("number", 0)),
+                         "time": round(float(s.get("start_time", 0)), 3)}
+                        for s in sections
+                    ]
+                return wire
 
             # Determine the arrangement set to write. If `arrangements` was
-            # provided, it's the authoritative full snapshot (handles adds
-            # and reorders). Otherwise we update only the single arrangement
-            # at arrangement_index using notes/chords/chord_templates.
+            # provided, it's the authoritative full snapshot (handles adds,
+            # removes, reorders). Otherwise we update only the single
+            # arrangement at arrangement_index from notes/chords/templates.
+            old_entries = list(manifest.get("arrangements", []) or [])
+
             if all_arrangements is None:
-                if arrangement_index >= len(existing_ids):
-                    raise RuntimeError("Invalid arrangement index")
-                # Fetch the current manifest entry for the edited arrangement
-                # so we keep its name/tuning/capo.
-                old_entries = manifest.get("arrangements", []) or []
                 if arrangement_index >= len(old_entries):
-                    raise RuntimeError("Manifest arrangement out of range")
+                    raise RuntimeError("Invalid arrangement index")
+                # Build a synthetic edited dict using the old entry's
+                # tuning/capo since the legacy save body doesn't carry them.
                 old_entry = old_entries[arrangement_index]
+                edited_dict = {
+                    "name": old_entry.get("name", ""),
+                    "tuning": old_entry.get("tuning", [0]*6),
+                    "capo": int(old_entry.get("capo", 0)),
+                    "notes": notes,
+                    "chords": chords,
+                    "chord_templates": chord_templates,
+                    # Anchors/handshapes/phrases aren't sent in the legacy
+                    # body — the next reload will pull them from disk via
+                    # the unedited arrangement JSON, so leave wire defaults.
+                    "anchors": [], "handshapes": [], "phrases": None,
+                }
                 merged_arrangements = []
-                # We need to reconstruct the wire data for the edited
-                # arrangement only; other arrangements stay untouched.
                 for i, entry in enumerate(old_entries):
-                    if i == arrangement_index:
-                        wire = _arr_dict_to_wire(
-                            entry.get("name", ""),
-                            entry.get("tuning", [0]*6),
-                            int(entry.get("capo", 0)),
-                            notes, chords, chord_templates,
-                        )
-                        # First arrangement carries beats/sections.
-                        if i == 0:
-                            wire["beats"] = [
-                                {"time": round(float(b.get("time", 0)), 3),
-                                 "measure": int(b.get("measure", -1))}
-                                for b in beats
-                            ]
-                            wire["sections"] = [
-                                {"name": s.get("name", ""),
-                                 "number": int(s.get("number", 0)),
-                                 "time": round(float(s.get("start_time", 0)), 3)}
-                                for s in sections
-                            ]
-                        merged_arrangements.append({
-                            "entry": entry,
-                            "wire": wire,
-                        })
-                    else:
-                        merged_arrangements.append({"entry": entry, "wire": None})
+                    wire = _build_wire(edited_dict, i == 0) if i == arrangement_index else None
+                    merged_arrangements.append({"entry": entry, "wire": wire})
             else:
-                # Full snapshot path — used when arrangements were added/removed
-                # or for safety on every save.
+                # Full snapshot path — used when arrangements were added/
+                # removed or for safety on every save.
                 used_ids: set = set()
                 merged_arrangements = []
-                first = True
                 for i, ad in enumerate(all_arrangements):
                     aid = ad.get("id") or _arrangement_id(ad.get("name", "arr"), used_ids)
                     used_ids.add(aid)
-                    wire = _arr_dict_to_wire(
-                        ad.get("name", "arr"),
-                        ad.get("tuning", [0]*6),
-                        int(ad.get("capo", 0)),
-                        ad.get("notes", []),
-                        ad.get("chords", []),
-                        ad.get("chord_templates", []),
-                    )
-                    if first:
-                        wire["beats"] = [
-                            {"time": round(float(b.get("time", 0)), 3),
-                             "measure": int(b.get("measure", -1))}
-                            for b in beats
-                        ]
-                        wire["sections"] = [
-                            {"name": s.get("name", ""),
-                             "number": int(s.get("number", 0)),
-                             "time": round(float(s.get("start_time", 0)), 3)}
-                            for s in sections
-                        ]
-                        first = False
+                    wire = _build_wire(ad, i == 0)
                     merged_arrangements.append({
                         "entry": {
                             "id": aid,
@@ -354,8 +417,8 @@ def setup(app, context):
                         "wire": wire,
                     })
 
-            # Write/update arrangement JSON files inside source_dir
-            arr_dir = source_dir / "arrangements"
+            # Write/update arrangement JSON files inside source_dir/arrangements
+            arr_dir = (source_dir / "arrangements").resolve()
             arr_dir.mkdir(parents=True, exist_ok=True)
             new_manifest_arrangements = []
             kept_paths: set[Path] = set()
@@ -363,9 +426,14 @@ def setup(app, context):
                 entry = item["entry"]
                 wire = item["wire"]
                 if wire is not None:
-                    # Determine target path — fall back to default if missing
                     rel = entry.get("file") or f"arrangements/{entry.get('id', 'arr')}.json"
-                    arr_path = source_dir / rel
+                    arr_path = (source_dir / rel).resolve()
+                    # Constrain writes to the arrangements/ subdir — defends
+                    # against `..` traversal in a malformed/buggy snapshot.
+                    try:
+                        arr_path.relative_to(arr_dir)
+                    except ValueError:
+                        raise RuntimeError(f"Arrangement path escapes sandbox: {rel}")
                     arr_path.parent.mkdir(parents=True, exist_ok=True)
                     arr_path.write_text(
                         json.dumps(wire, separators=(",", ":")),
@@ -373,22 +441,19 @@ def setup(app, context):
                     )
                     entry = dict(entry)
                     entry["file"] = rel
-                # Track every kept arrangement file (rewritten or untouched)
-                rel = entry.get("file")
-                if rel:
-                    kept_paths.add((source_dir / rel).resolve())
+                rel_kept = entry.get("file")
+                if rel_kept:
+                    kept_paths.add((source_dir / rel_kept).resolve())
                 new_manifest_arrangements.append(entry)
             manifest["arrangements"] = new_manifest_arrangements
 
-            # Drop orphaned arrangement JSONs (e.g. after a remove). Only
-            # touches files inside the arrangements/ subdir to be safe.
-            if arr_dir.exists():
-                for f in arr_dir.glob("*.json"):
-                    if f.resolve() not in kept_paths:
-                        try:
-                            f.unlink()
-                        except OSError:
-                            pass
+            # Drop orphaned arrangement JSONs (e.g. after a remove).
+            for f in arr_dir.glob("*.json"):
+                if f.resolve() not in kept_paths:
+                    try:
+                        f.unlink()
+                    except OSError:
+                        pass
 
             # Apply edited top-level metadata (title/artist/album/year only —
             # don't let the editor overwrite stems/lyrics/cover paths).
@@ -408,13 +473,17 @@ def setup(app, context):
                 encoding="utf-8",
             )
 
-            # Backup original .sloppak (zip) if not already
-            if output_path.exists():
+            # Directory-form sloppak: source_dir IS the sloppak — we've already
+            # rewritten everything in place. Don't try to zip on top of it.
+            if sloppak_form == "dir":
+                return str(output_path)
+
+            # Zip-form: back up the original and re-zip the source dir.
+            if output_path.exists() and output_path.is_file():
                 backup = dlc_dir / (filename + ".bak")
                 if not backup.exists():
                     shutil.copy2(output_path, backup)
 
-            # Re-zip the source dir into the .sloppak file
             output_path.parent.mkdir(parents=True, exist_ok=True)
             tmp_zip = output_path.with_suffix(output_path.suffix + ".tmp")
             with zipfile.ZipFile(str(tmp_zip), "w", zipfile.ZIP_DEFLATED) as zf:
@@ -569,12 +638,14 @@ def setup(app, context):
         """Convert a MIDI track into a Keys arrangement (editor-ready dict)."""
         from lib.midi_import import convert_midi_track_to_keys_wire
 
-        midi_path = data.get("midi_path", "")
+        midi_path_raw = data.get("midi_path", "")
         track_index = data.get("track_index")
         audio_offset = float(data.get("audio_offset", 0.0))
 
-        if not midi_path or not Path(midi_path).exists():
+        validated = _validate_editor_upload_path(midi_path_raw, "slopsmith_midi_")
+        if not validated:
             return JSONResponse({"error": "MIDI file not found"}, 400)
+        midi_path = str(validated)
         if track_index is None:
             return JSONResponse({"error": "track_index required"}, 400)
 
@@ -643,8 +714,10 @@ def setup(app, context):
         album = data.get("album", "")
         year = data.get("year", "")
 
-        if not gp_path or not Path(gp_path).exists():
+        validated_gp = _validate_editor_upload_path(gp_path, "slopsmith_gp_")
+        if not validated_gp:
             return JSONResponse({"error": "GP file not found"}, 400)
+        gp_path = str(validated_gp)
 
         def _convert():
             tmp = tempfile.mkdtemp(prefix="slopsmith_editor_create_")
@@ -760,12 +833,14 @@ def setup(app, context):
         from lib.song import parse_arrangement, Song, Beat, Section
         import guitarpro
 
-        gp_path = data.get("gp_path", "")
+        gp_path_raw = data.get("gp_path", "")
         track_index = data.get("track_index")
         audio_offset = data.get("audio_offset", 0.0)
 
-        if not gp_path or not Path(gp_path).exists():
+        validated = _validate_editor_upload_path(gp_path_raw, "slopsmith_gp_")
+        if not validated:
             return JSONResponse({"error": "GP file not found"}, 400)
+        gp_path = str(validated)
         if track_index is None:
             return JSONResponse({"error": "track_index required"}, 400)
 
@@ -784,7 +859,7 @@ def setup(app, context):
             # Write to temp file so we can parse it back
             tmp = tempfile.mkdtemp(prefix="slopsmith_keys_")
             xml_path = os.path.join(tmp, "Keys.xml")
-            Path(xml_path).write_text(xml_str)
+            Path(xml_path).write_text(xml_str, encoding="utf-8")
 
             arr = parse_arrangement(xml_path)
             arr_data = {
@@ -881,12 +956,14 @@ def setup(app, context):
         from lib.song import parse_arrangement, Song, Beat, Section
         import guitarpro
 
-        gp_path = data.get("gp_path", "")
+        gp_path_raw = data.get("gp_path", "")
         track_index = data.get("track_index")
         audio_offset = data.get("audio_offset", 0.0)
 
-        if not gp_path or not Path(gp_path).exists():
+        validated = _validate_editor_upload_path(gp_path_raw, "slopsmith_gp_")
+        if not validated:
             return JSONResponse({"error": "GP file not found"}, 400)
+        gp_path = str(validated)
         if track_index is None:
             return JSONResponse({"error": "track_index required"}, 400)
 
@@ -900,7 +977,7 @@ def setup(app, context):
             # Write to temp file so we can parse it back
             tmp = tempfile.mkdtemp(prefix="slopsmith_drums_")
             xml_path = os.path.join(tmp, "Drums.xml")
-            Path(xml_path).write_text(xml_str)
+            Path(xml_path).write_text(xml_str, encoding="utf-8")
 
             arr = parse_arrangement(xml_path)
             arr_data = {
@@ -1086,7 +1163,7 @@ def setup(app, context):
                     old_root, arr_notes, arr_chords, arr_templates,
                     beats, sections, meta,
                 )
-                Path(xml_path).write_text(xml_str)
+                Path(xml_path).write_text(xml_str, encoding="utf-8")
 
             # Resolve audio file path from URL
             audio_file = ""

--- a/routes.py
+++ b/routes.py
@@ -398,6 +398,8 @@ def setup(app, context):
             sloppak_form = sloppak_state.get("form") or "zip"
             source_dir = Path(session["dir"]).resolve()
             dlc_dir = get_dlc_dir()
+            if not dlc_dir:
+                raise RuntimeError("DLC folder not configured")
             filename = session["filename"]
             output_path = (dlc_dir / filename).resolve()
 
@@ -450,14 +452,24 @@ def setup(app, context):
                 _preserved: dict = {}
                 _old_rel = old_entry.get("file")
                 if _old_rel:
-                    _old_path = source_dir / _old_rel
+                    _old_path = (source_dir / _old_rel).resolve()
+                    # Constrain reads to source_dir/arrangements — defends against
+                    # `..` traversal in a malformed or untrusted manifest.yaml.
+                    _arr_dir_resolved = (source_dir / "arrangements").resolve()
+                    _old_path_ok = False
                     try:
-                        _existing = json.loads(_old_path.read_text(encoding="utf-8"))
-                        for _k in ("anchors", "handshapes", "phrases"):
-                            if _k in _existing:
-                                _preserved[_k] = _existing[_k]
-                    except (OSError, json.JSONDecodeError):
+                        _old_path.relative_to(_arr_dir_resolved)
+                        _old_path_ok = True
+                    except ValueError:
                         pass
+                    if _old_path_ok:
+                        try:
+                            _existing = json.loads(_old_path.read_text(encoding="utf-8"))
+                            for _k in ("anchors", "handshapes", "phrases"):
+                                if _k in _existing:
+                                    _preserved[_k] = _existing[_k]
+                        except (OSError, json.JSONDecodeError):
+                            pass
                 edited_dict = {
                     "name": old_entry.get("name", ""),
                     "tuning": old_entry.get("tuning", [0]*6),
@@ -784,6 +796,10 @@ def setup(app, context):
             import traceback
             traceback.print_exc()
             return JSONResponse({"error": str(e)}, 500)
+
+        # Clean up the MIDI temp dir now that conversion is complete — the
+        # client no longer needs to reference midi_path after this response.
+        shutil.rmtree(Path(midi_path).parent, ignore_errors=True)
 
         return {"arrangement": arr_data}
 

--- a/routes.py
+++ b/routes.py
@@ -1137,11 +1137,35 @@ def setup(app, context):
         xml_files = session.get("xml_files") or []
         if 0 <= idx < len(xml_files):
             removed = xml_files.pop(idx)
-            # Delete the XML file
+            # Delete the XML and every sidecar that pack_psarc would
+            # otherwise repack from the session dir. The CDLC layout
+            # stores per-arrangement assets keyed off the XML stem:
+            #   songs/arr/<stem>.xml          (this file)
+            #   songs/bin/generic/<stem>.sng  (compiled chart)
+            #   manifests/songs_dlc_*/<stem>.json (RS manifest)
+            # Without removing the .sng + manifest, the next save would
+            # repack a CDLC that still ships the "removed" arrangement.
+            xml_p = Path(removed)
+            stem = xml_p.stem
+            session_dir = Path(session.get("dir") or "")
+
             try:
-                Path(removed).unlink(missing_ok=True)
+                xml_p.unlink(missing_ok=True)
             except Exception:
                 pass
+
+            sng_path = xml_p.parent.parent / "bin" / "generic" / f"{stem}.sng"
+            try:
+                sng_path.unlink(missing_ok=True)
+            except Exception:
+                pass
+
+            if session_dir and session_dir.is_dir():
+                for manifest_json in session_dir.rglob(f"manifests/**/{stem}.json"):
+                    try:
+                        manifest_json.unlink(missing_ok=True)
+                    except Exception:
+                        pass
 
         return {"success": True, "arrangement_count": len(xml_files)}
 

--- a/routes.py
+++ b/routes.py
@@ -458,6 +458,8 @@ def setup(app, context):
                     _arr_dir_resolved = (source_dir / "arrangements").resolve()
                     _old_path_ok = False
                     try:
+                        # Called only for the side-effect: raises ValueError
+                        # if _old_path escapes _arr_dir_resolved (path traversal).
                         _old_path.relative_to(_arr_dir_resolved)
                         _old_path_ok = True
                     except ValueError:
@@ -799,7 +801,11 @@ def setup(app, context):
 
         # Clean up the MIDI temp dir now that conversion is complete — the
         # client no longer needs to reference midi_path after this response.
-        shutil.rmtree(Path(midi_path).parent, ignore_errors=True)
+        try:
+            shutil.rmtree(Path(midi_path).parent)
+        except OSError as _cleanup_err:
+            import warnings
+            warnings.warn(f"Could not clean up MIDI temp dir: {_cleanup_err}")
 
         return {"arrangement": arr_data}
 

--- a/routes.py
+++ b/routes.py
@@ -111,7 +111,9 @@ def setup(app, context):
                 if rel not in seen:
                     seen.add(rel)
                     files.append({"filename": rel, "format": fmt})
-            # Also check sub-dirs with a .sloppak suffix (authoring form).
+            # Collect authoring-form .sloppak/ dirs and prune them from
+            # dirnames so os.walk won't descend into their contents.
+            to_prune = []
             for name in dirnames:
                 ext = os.path.splitext(name)[1].lower()
                 if ext == ".sloppak":
@@ -120,6 +122,9 @@ def setup(app, context):
                     if rel not in seen:
                         seen.add(rel)
                         files.append({"filename": rel, "format": "sloppak"})
+                    to_prune.append(name)
+            for name in to_prune:
+                dirnames.remove(name)
         files.sort(key=lambda x: x["filename"])
         return files
 
@@ -142,12 +147,12 @@ def setup(app, context):
             filepath.relative_to(dlc_dir.resolve())
         except ValueError:
             return JSONResponse({"error": "Invalid filename"}, 400)
-        if filepath.suffix not in (".psarc", ".sloppak"):
+        if filepath.suffix.lower() not in (".psarc", ".sloppak"):
             return JSONResponse({"error": "Unsupported file type"}, 400)
         if not filepath.exists():
             return JSONResponse({"error": "File not found"}, 404)
 
-        is_sloppak = filepath.suffix == ".sloppak"
+        is_sloppak = filepath.suffix.lower() == ".sloppak"
 
         def _load_psarc():
             tmp_dir = tempfile.mkdtemp(prefix="slopsmith_editor_")

--- a/routes.py
+++ b/routes.py
@@ -497,9 +497,9 @@ def setup(app, context):
                     raw_id = ad.get("id") or ""
                     if raw_id and raw_id not in used_ids:
                         aid = raw_id
-                        used_ids.add(aid)
                     else:
                         aid = _arrangement_id(ad.get("name", "arr"), used_ids)
+                    used_ids.add(aid)
                     wire = _build_wire(ad, i == 0)
                     merged_arrangements.append({
                         "entry": {

--- a/routes.py
+++ b/routes.py
@@ -83,12 +83,13 @@ def setup(app, context):
             return []
         files = []
         for f in dlc_dir.rglob("*"):
-            if not f.is_file():
-                continue
-            if f.suffix == ".psarc":
-                files.append({"filename": str(f.relative_to(dlc_dir)), "format": "psarc"})
-            elif f.suffix == ".sloppak":
+            # Sloppak has two valid forms: zip (`.sloppak` file) and
+            # authoring directory (`.sloppak/`). load_cdlc + _save_sloppak
+            # already handle both forms; the picker has to surface both too.
+            if f.suffix == ".sloppak":
                 files.append({"filename": str(f.relative_to(dlc_dir)), "format": "sloppak"})
+            elif f.is_file() and f.suffix == ".psarc":
+                files.append({"filename": str(f.relative_to(dlc_dir)), "format": "psarc"})
         files.sort(key=lambda x: x["filename"])
         return files
 
@@ -641,6 +642,17 @@ def setup(app, context):
         midi_path_raw = data.get("midi_path", "")
         track_index = data.get("track_index")
         audio_offset = float(data.get("audio_offset", 0.0))
+        # Optional: when the picker entry came from a format-0 channel
+        # split, this isolates the chosen channel out of the merged track.
+        channel_filter_raw = data.get("channel_filter")
+        channel_filter: int | None
+        if channel_filter_raw is None or channel_filter_raw == "":
+            channel_filter = None
+        else:
+            try:
+                channel_filter = int(channel_filter_raw)
+            except (TypeError, ValueError):
+                channel_filter = None
 
         validated = _validate_editor_upload_path(midi_path_raw, "slopsmith_midi_")
         if not validated:
@@ -651,7 +663,8 @@ def setup(app, context):
 
         def _convert():
             wire = convert_midi_track_to_keys_wire(
-                midi_path, int(track_index), audio_offset, "Keys"
+                midi_path, int(track_index), audio_offset, "Keys",
+                channel_filter=channel_filter,
             )
             # Convert wire → editor's long-named shape so the frontend can
             # consume it identically to import-keys output.

--- a/routes.py
+++ b/routes.py
@@ -345,7 +345,11 @@ def setup(app, context):
         if not session:
             return JSONResponse({"error": "No active session"}, 400)
 
-        arrangement_index = data.get("arrangement_index", 0)
+        raw_arr_idx = data.get("arrangement_index", 0)
+        try:
+            arrangement_index = int(raw_arr_idx)
+        except (TypeError, ValueError):
+            return JSONResponse({"error": "arrangement_index must be an integer"}, 400)
         notes = data.get("notes", [])
         chords = data.get("chords", [])
         chord_templates = data.get("chord_templates", [])
@@ -1229,7 +1233,11 @@ def setup(app, context):
         if not session:
             return JSONResponse({"error": "No active session"}, 400)
 
-        idx = data.get("arrangement_index", -1)
+        raw_idx = data.get("arrangement_index", -1)
+        try:
+            idx = int(raw_idx)
+        except (TypeError, ValueError):
+            return JSONResponse({"error": "arrangement_index must be an integer"}, 400)
 
         # Sloppak: nothing to remove server-side until save. The frontend
         # splices its in-memory arrangements and the next save rewrites

--- a/routes.py
+++ b/routes.py
@@ -92,14 +92,21 @@ def setup(app, context):
         if not dlc_dir or not dlc_dir.exists():
             return []
         files = []
-        for f in dlc_dir.rglob("*"):
-            # Sloppak has two valid forms: zip (`.sloppak` file) and
-            # authoring directory (`.sloppak/`). load_cdlc + _save_sloppak
-            # already handle both forms; the picker has to surface both too.
-            if f.suffix == ".sloppak":
-                files.append({"filename": str(f.relative_to(dlc_dir)), "format": "sloppak"})
-            elif f.is_file() and f.suffix == ".psarc":
-                files.append({"filename": str(f.relative_to(dlc_dir)), "format": "psarc"})
+        seen: set = set()
+        # Sloppak has two valid forms: zip (`.sloppak` file) and authoring
+        # directory (`.sloppak/`). Use targeted globs so we avoid stat-ing
+        # every unrelated file in potentially large libraries.
+        for f in dlc_dir.rglob("*.sloppak"):
+            rel = str(f.relative_to(dlc_dir))
+            if rel not in seen:
+                seen.add(rel)
+                files.append({"filename": rel, "format": "sloppak"})
+        for f in dlc_dir.rglob("*.psarc"):
+            if f.is_file():
+                rel = str(f.relative_to(dlc_dir))
+                if rel not in seen:
+                    seen.add(rel)
+                    files.append({"filename": rel, "format": "psarc"})
         files.sort(key=lambda x: x["filename"])
         return files
 
@@ -437,6 +444,20 @@ def setup(app, context):
                 # Build a synthetic edited dict using the old entry's
                 # tuning/capo since the legacy save body doesn't carry them.
                 old_entry = old_entries[arrangement_index]
+                # Load anchors/handshapes/phrases from the existing arrangement
+                # JSON on disk so they are preserved verbatim — the editor UI
+                # doesn't expose them, so the save body never includes them.
+                _preserved: dict = {}
+                _old_rel = old_entry.get("file")
+                if _old_rel:
+                    _old_path = source_dir / _old_rel
+                    try:
+                        _existing = json.loads(_old_path.read_text(encoding="utf-8"))
+                        for _k in ("anchors", "handshapes", "phrases"):
+                            if _k in _existing:
+                                _preserved[_k] = _existing[_k]
+                    except (OSError, json.JSONDecodeError):
+                        pass
                 edited_dict = {
                     "name": old_entry.get("name", ""),
                     "tuning": old_entry.get("tuning", [0]*6),
@@ -444,10 +465,9 @@ def setup(app, context):
                     "notes": notes,
                     "chords": chords,
                     "chord_templates": chord_templates,
-                    # Anchors/handshapes/phrases aren't sent in the legacy
-                    # body — the next reload will pull them from disk via
-                    # the unedited arrangement JSON, so leave wire defaults.
-                    "anchors": [], "handshapes": [], "phrases": None,
+                    "anchors": _preserved.get("anchors", []),
+                    "handshapes": _preserved.get("handshapes", []),
+                    "phrases": _preserved.get("phrases"),
                 }
                 merged_arrangements = []
                 for i, entry in enumerate(old_entries):

--- a/routes.py
+++ b/routes.py
@@ -704,7 +704,29 @@ def setup(app, context):
         """Upload a MIDI file and return track listing."""
         from lib.midi_import import list_midi_tracks
 
-        suffix = Path(file.filename or "song.mid").suffix or ".mid"
+        # Validate extension — the browser accept filter is advisory only.
+        orig_suffix = Path(file.filename or "").suffix.lower()
+        if orig_suffix not in (".mid", ".midi"):
+            return JSONResponse(
+                {"error": "Only .mid/.midi files are accepted"}, 400
+            )
+
+        # Opportunistic TTL cleanup: remove any slopsmith_midi_* sandbox dirs
+        # older than 30 minutes so unclaimed uploads (cancelled modals, etc.)
+        # don't accumulate indefinitely on the server.
+        import time as _time
+        _ttl_secs = 30 * 60
+        _tmp_root = Path(tempfile.gettempdir())
+        for _stale in _tmp_root.glob("slopsmith_midi_*"):
+            try:
+                if _stale.is_dir():
+                    age = _time.time() - _stale.stat().st_mtime
+                    if age > _ttl_secs:
+                        shutil.rmtree(_stale, ignore_errors=True)
+            except OSError:
+                pass
+
+        suffix = orig_suffix or ".mid"
         tmp = tempfile.mkdtemp(prefix="slopsmith_midi_")
         midi_path = os.path.join(tmp, "upload" + suffix)
         content = await file.read()

--- a/routes.py
+++ b/routes.py
@@ -200,6 +200,18 @@ def setup(app, context):
 
             result = _song_to_dict(song, audio_url)
             result["format"] = "sloppak"
+            # `lib/sloppak.load_song()` doesn't restore song.offset (the
+            # sloppak format doesn't carry an explicit offset field today),
+            # so song.offset is 0 here. If the manifest happens to surface
+            # one (e.g. a forward-compat extension that mirrors PSARC's
+            # song-level <offset>), pick it up so the audio_offset that
+            # gets fed to the +Keys/+Drums converters matches the chart.
+            try:
+                manifest_offset = float(loaded.manifest.get("offset", 0) or 0)
+            except (TypeError, ValueError):
+                manifest_offset = 0.0
+            if manifest_offset:
+                result["offset"] = manifest_offset
             # Carry the manifest-derived arrangement id list onto each
             # arrangement so the frontend can round-trip it back to us.
             # Use a single `used_ids` set when generating fallback ids so two
@@ -254,7 +266,16 @@ def setup(app, context):
             traceback.print_exc()
             return JSONResponse({"error": str(e)}, 500)
 
-        session_id = Path(filename).stem
+        # Session id has to disambiguate the full relative path, not just
+        # the basename — the picker now emits paths like `foo/bar.psarc`
+        # and `baz/bar.sloppak` that share the same stem, and a basename-
+        # keyed session would have two browser tabs collide on `bar`,
+        # corrupting the second's saves into the first's working dir.
+        # Sanitise path separators / spaces into a stable id (matches the
+        # `lib.sloppak._safe_id` convention) and append the suffix so a
+        # `.psarc` and `.sloppak` of the same name still get distinct ids.
+        sanitised = filename.replace("/", "__").replace("\\", "__").replace(" ", "_")
+        session_id = sanitised
         # Clean up previous PSARC session for same file (sloppak sessions
         # use the cache dir directly — never delete it on session swap).
         if session_id in sessions:

--- a/routes.py
+++ b/routes.py
@@ -94,20 +94,32 @@ def setup(app, context):
             return []
         files = []
         seen: set = set()
+        # Single os.walk pass so large libraries are traversed only once.
         # Sloppak has two valid forms: zip (`.sloppak` file) and authoring
-        # directory (`.sloppak/`). Use targeted globs so we avoid stat-ing
-        # every unrelated file in potentially large libraries.
-        for f in dlc_dir.rglob("*.sloppak"):
-            rel = str(f.relative_to(dlc_dir))
-            if rel not in seen:
-                seen.add(rel)
-                files.append({"filename": rel, "format": "sloppak"})
-        for f in dlc_dir.rglob("*.psarc"):
-            if f.is_file():
-                rel = str(f.relative_to(dlc_dir))
+        # directory (`.sloppak/`).  All suffixes are lowercased so that
+        # e.g. `.PSARC` / `.SLOPPAK` from older backends are handled correctly.
+        _FORMATS = {".sloppak": "sloppak", ".psarc": "psarc"}
+        for dirpath, dirnames, filenames in os.walk(dlc_dir):
+            dirnames.sort()
+            for name in filenames:
+                ext = os.path.splitext(name)[1].lower()
+                fmt = _FORMATS.get(ext)
+                if fmt is None:
+                    continue
+                full = Path(dirpath) / name
+                rel = str(full.relative_to(dlc_dir))
                 if rel not in seen:
                     seen.add(rel)
-                    files.append({"filename": rel, "format": "psarc"})
+                    files.append({"filename": rel, "format": fmt})
+            # Also check sub-dirs with a .sloppak suffix (authoring form).
+            for name in dirnames:
+                ext = os.path.splitext(name)[1].lower()
+                if ext == ".sloppak":
+                    full = Path(dirpath) / name
+                    rel = str(full.relative_to(dlc_dir))
+                    if rel not in seen:
+                        seen.add(rel)
+                        files.append({"filename": rel, "format": "sloppak"})
         files.sort(key=lambda x: x["filename"])
         return files
 
@@ -353,6 +365,8 @@ def setup(app, context):
                 arrangement_index = int(raw_arr_idx)
             except (TypeError, ValueError):
                 return JSONResponse({"error": "arrangement_index must be an integer"}, 400)
+        if arrangement_index < 0:
+            return JSONResponse({"error": "arrangement_index must be non-negative"}, 400)
         notes = data.get("notes", [])
         chords = data.get("chords", [])
         chord_templates = data.get("chord_templates", [])
@@ -1252,37 +1266,38 @@ def setup(app, context):
             return {"success": True, "arrangement_count": -1, "format": "sloppak"}
 
         xml_files = session.get("xml_files") or []
-        if 0 <= idx < len(xml_files):
-            removed = xml_files.pop(idx)
-            # Delete the XML and every sidecar that pack_psarc would
-            # otherwise repack from the session dir. The CDLC layout
-            # stores per-arrangement assets keyed off the XML stem:
-            #   songs/arr/<stem>.xml          (this file)
-            #   songs/bin/generic/<stem>.sng  (compiled chart)
-            #   manifests/songs_dlc_*/<stem>.json (RS manifest)
-            # Without removing the .sng + manifest, the next save would
-            # repack a CDLC that still ships the "removed" arrangement.
-            xml_p = Path(removed)
-            stem = xml_p.stem
-            session_dir = Path(session.get("dir") or "")
+        if not (0 <= idx < len(xml_files)):
+            return JSONResponse({"error": "arrangement_index out of range"}, 400)
+        removed = xml_files.pop(idx)
+        # Delete the XML and every sidecar that pack_psarc would
+        # otherwise repack from the session dir. The CDLC layout
+        # stores per-arrangement assets keyed off the XML stem:
+        #   songs/arr/<stem>.xml          (this file)
+        #   songs/bin/generic/<stem>.sng  (compiled chart)
+        #   manifests/songs_dlc_*/<stem>.json (RS manifest)
+        # Without removing the .sng + manifest, the next save would
+        # repack a CDLC that still ships the "removed" arrangement.
+        xml_p = Path(removed)
+        stem = xml_p.stem
+        session_dir = Path(session.get("dir") or "")
 
-            try:
-                xml_p.unlink(missing_ok=True)
-            except Exception:
-                pass
+        try:
+            xml_p.unlink(missing_ok=True)
+        except Exception:
+            pass
 
-            sng_path = xml_p.parent.parent / "bin" / "generic" / f"{stem}.sng"
-            try:
-                sng_path.unlink(missing_ok=True)
-            except Exception:
-                pass
+        sng_path = xml_p.parent.parent / "bin" / "generic" / f"{stem}.sng"
+        try:
+            sng_path.unlink(missing_ok=True)
+        except Exception:
+            pass
 
-            if session_dir and session_dir.is_dir():
-                for manifest_json in session_dir.rglob(f"manifests/**/{stem}.json"):
-                    try:
-                        manifest_json.unlink(missing_ok=True)
-                    except Exception:
-                        pass
+        if session_dir and session_dir.is_dir():
+            for manifest_json in session_dir.rglob(f"manifests/**/{stem}.json"):
+                try:
+                    manifest_json.unlink(missing_ok=True)
+                except Exception:
+                    pass
 
         return {"success": True, "arrangement_count": len(xml_files)}
 

--- a/routes.py
+++ b/routes.py
@@ -31,7 +31,17 @@ def setup(app, context):
     from lib import sloppak as sloppak_mod
 
     STATIC_DIR = Path(__file__).resolve().parent.parent.parent / "static"
-    SLOPPAK_CACHE = STATIC_DIR / "sloppak_cache"
+    # The unpack cache must NOT live under STATIC_DIR — that directory is
+    # mounted as the public /static web root, so anything under it is
+    # downloadable by URL. Stems / manifests / covers of every loaded
+    # sloppak would leak. Use the shared private cache the server exposes
+    # via the plugin context (lives under CONFIG_DIR), with a fall-back
+    # for any older harness that doesn't surface the helper.
+    _get_sloppak_cache = context.get("get_sloppak_cache_dir")
+    if callable(_get_sloppak_cache):
+        SLOPPAK_CACHE = Path(_get_sloppak_cache())
+    else:
+        SLOPPAK_CACHE = config_dir / "sloppak_cache"
 
     # Active editing sessions: session_id -> {dir, audio_file, filename, song_data}
     sessions = {}
@@ -138,7 +148,12 @@ def setup(app, context):
                         wem_files[0], os.path.join(tmp_dir, "audio")
                     )
                     audio_file = audio_path
-                    audio_id = Path(filename).stem.replace(" ", "_")
+                    # Sanitise the full relative path (not just .stem) so
+                    # nested `foo/bar.psarc` and `baz/bar.psarc` don't
+                    # overwrite each other's editor_audio_*.* file under
+                    # STATIC_DIR. Matches the sloppak path's id scheme
+                    # and the session_id sanitisation.
+                    audio_id = filename.replace("/", "__").replace("\\", "__").replace(" ", "_")
                     ext = Path(audio_path).suffix
                     dest = STATIC_DIR / f"editor_audio_{audio_id}{ext}"
                     shutil.copy2(audio_path, dest)
@@ -191,7 +206,12 @@ def setup(app, context):
             if stem_path is None and loaded.stems:
                 stem_path = loaded.source_dir / loaded.stems[0].get("file", "")
             if stem_path and stem_path.exists():
-                audio_id = Path(filename).stem.replace(" ", "_").replace("/", "_")
+                # Same basename-collision class as session_id: nested paths
+                # like `foo/bar.psarc` and `baz/bar.sloppak` both reduce
+                # to stem "bar". Use a sanitised full path so two browser
+                # tabs loading distinct songs don't overwrite each other's
+                # `editor_audio_*` file under STATIC_DIR.
+                audio_id = filename.replace("/", "__").replace("\\", "__").replace(" ", "_")
                 ext = stem_path.suffix
                 dest = STATIC_DIR / f"editor_audio_{audio_id}{ext}"
                 shutil.copy2(stem_path, dest)

--- a/routes.py
+++ b/routes.py
@@ -205,9 +205,10 @@ def setup(app, context):
                 rel = stem_entry.get("file", "")
                 if not rel:
                     return None
+                source_resolved = loaded.source_dir.resolve()
                 candidate = (loaded.source_dir / rel).resolve()
                 try:
-                    candidate.relative_to(loaded.source_dir.resolve())
+                    candidate.relative_to(source_resolved)
                 except ValueError:
                     return None
                 return candidate if candidate.exists() else None

--- a/routes.py
+++ b/routes.py
@@ -199,12 +199,25 @@ def setup(app, context):
             audio_url = None
             audio_file = None
             stem_path = None
+
+            def _safe_stem_path(stem_entry: dict) -> "Path | None":
+                """Resolve stem file path and reject traversal outside source_dir."""
+                rel = stem_entry.get("file", "")
+                if not rel:
+                    return None
+                candidate = (loaded.source_dir / rel).resolve()
+                try:
+                    candidate.relative_to(loaded.source_dir.resolve())
+                except ValueError:
+                    return None
+                return candidate if candidate.exists() else None
+
             for s in loaded.stems:
                 if s.get("id") == "full":
-                    stem_path = loaded.source_dir / s.get("file", "")
+                    stem_path = _safe_stem_path(s)
                     break
             if stem_path is None and loaded.stems:
-                stem_path = loaded.source_dir / loaded.stems[0].get("file", "")
+                stem_path = _safe_stem_path(loaded.stems[0])
             if stem_path and stem_path.exists():
                 # Same basename-collision class as session_id: nested paths
                 # like `foo/bar.psarc` and `baz/bar.sloppak` both reduce
@@ -682,7 +695,10 @@ def setup(app, context):
 
         midi_path_raw = data.get("midi_path", "")
         track_index = data.get("track_index")
-        audio_offset = float(data.get("audio_offset", 0.0))
+        try:
+            audio_offset = float(data.get("audio_offset", 0.0))
+        except (TypeError, ValueError):
+            return JSONResponse({"error": "audio_offset must be a number"}, 400)
         # Optional: when the picker entry came from a format-0 channel
         # split, this isolates the chosen channel out of the merged track.
         channel_filter_raw = data.get("channel_filter")
@@ -889,7 +905,10 @@ def setup(app, context):
 
         gp_path_raw = data.get("gp_path", "")
         track_index = data.get("track_index")
-        audio_offset = data.get("audio_offset", 0.0)
+        try:
+            audio_offset = float(data.get("audio_offset", 0.0))
+        except (TypeError, ValueError):
+            return JSONResponse({"error": "audio_offset must be a number"}, 400)
 
         validated = _validate_editor_upload_path(gp_path_raw, "slopsmith_gp_")
         if not validated:
@@ -1012,7 +1031,10 @@ def setup(app, context):
 
         gp_path_raw = data.get("gp_path", "")
         track_index = data.get("track_index")
-        audio_offset = data.get("audio_offset", 0.0)
+        try:
+            audio_offset = float(data.get("audio_offset", 0.0))
+        except (TypeError, ValueError):
+            return JSONResponse({"error": "audio_offset must be a number"}, 400)
 
         validated = _validate_editor_upload_path(gp_path_raw, "slopsmith_gp_")
         if not validated:

--- a/routes.py
+++ b/routes.py
@@ -96,7 +96,7 @@ def setup(app, context):
         seen: set = set()
         # Single os.walk pass so large libraries are traversed only once.
         # Sloppak has two valid forms: zip (`.sloppak` file) and authoring
-        # directory (`.sloppak/`).  All suffixes are lowercased so that
+        # directory (`.sloppak/`). All suffixes are lowercased so that
         # e.g. `.PSARC` / `.SLOPPAK` from older backends are handled correctly.
         _FORMATS = {".sloppak": "sloppak", ".psarc": "psarc"}
         for dirpath, dirnames, filenames in os.walk(dlc_dir):

--- a/screen.html
+++ b/screen.html
@@ -13,6 +13,7 @@
         <!-- Arrangement selector -->
         <select id="editor-arrangement" class="bg-dark-700 border border-gray-700 rounded px-2 py-1 text-xs text-gray-300 outline-none" onchange="editorSelectArrangement(this.value)" style="display:none">
         </select>
+        <button id="editor-remove-arr-btn" onclick="editorRemoveArrangement()" class="px-2 py-1 bg-dark-600 hover:bg-red-900 rounded text-xs text-gray-500 hover:text-red-300 transition hidden" title="Remove current arrangement">&times;</button>
     </div>
 
     <!-- Toolbar -->
@@ -22,6 +23,8 @@
         <button id="editor-create-btn" onclick="editorShowCreateModal()" class="px-3 py-1 bg-green-800 hover:bg-green-700 rounded text-xs font-medium">Create</button>
         <button id="editor-save-btn" onclick="editorSave()" class="px-3 py-1 bg-accent hover:bg-accent-light rounded text-xs font-medium" disabled>Save</button>
         <button id="editor-build-btn" onclick="editorBuild()" class="px-3 py-1 bg-purple-800 hover:bg-purple-700 rounded text-xs font-medium hidden">Build CDLC</button>
+        <button id="editor-add-drums-btn" onclick="editorShowAddDrumsModal()" class="px-3 py-1 bg-red-900 hover:bg-red-800 rounded text-xs font-medium hidden">+ Drums</button>
+        <button id="editor-add-keys-btn" onclick="editorShowAddKeysModal()" class="px-3 py-1 bg-indigo-900 hover:bg-indigo-800 rounded text-xs font-medium hidden">+ Keys</button>
 
         <div class="h-4 w-px bg-gray-700"></div>
 
@@ -226,6 +229,61 @@
     <div class="flex gap-2 mt-3">
         <button onclick="editorApplySync()" class="flex-1 px-2 py-1 bg-accent hover:bg-accent-light rounded text-xs">Apply</button>
         <button onclick="editorHideSyncDialog()" class="flex-1 px-2 py-1 bg-dark-600 hover:bg-dark-500 rounded text-xs">Cancel</button>
+    </div>
+</div>
+
+<!-- Add drums modal -->
+<div id="editor-add-drums-modal" class="hidden absolute inset-0 z-50 flex items-center justify-center" style="background:rgba(0,0,0,0.7)">
+    <div class="bg-dark-700 rounded-xl border border-gray-700 w-full max-w-md flex flex-col">
+        <div class="flex items-center justify-between px-4 py-3 border-b border-gray-700">
+            <span class="text-sm font-medium">Add Drum Arrangement</span>
+            <button onclick="editorHideAddDrumsModal()" class="text-gray-500 hover:text-white">&times;</button>
+        </div>
+        <div class="p-4 space-y-3">
+            <div>
+                <label class="text-xs font-medium text-gray-400 mb-1 block">Guitar Pro File with Drum Track</label>
+                <input type="file" id="editor-add-drums-gp" accept=".gp3,.gp4,.gp5,.gpx,.gp"
+                    onchange="editorDrumsGPSelected(this)"
+                    class="w-full text-xs text-gray-400 file:mr-3 file:py-1 file:px-3 file:rounded file:border-0 file:text-xs file:bg-dark-600 file:text-gray-300 hover:file:bg-dark-500">
+            </div>
+            <div id="editor-add-drums-tracks" class="hidden">
+                <label class="text-xs font-medium text-gray-400 mb-1 block">Select Drum Track</label>
+                <div id="editor-add-drums-track-list" class="space-y-1 max-h-32 overflow-y-auto bg-dark-800 rounded p-2"></div>
+            </div>
+            <button onclick="editorDoAddDrums()" id="editor-add-drums-go"
+                class="w-full px-4 py-2 bg-red-700 hover:bg-red-600 rounded-lg text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed" disabled>
+                Import Drum Track
+            </button>
+            <div id="editor-add-drums-status" class="text-xs text-gray-500"></div>
+        </div>
+    </div>
+</div>
+
+<!-- Add keys modal -->
+<div id="editor-add-keys-modal" class="hidden absolute inset-0 z-50 flex items-center justify-center" style="background:rgba(0,0,0,0.7)">
+    <div class="bg-dark-700 rounded-xl border border-gray-700 w-full max-w-md flex flex-col">
+        <div class="flex items-center justify-between px-4 py-3 border-b border-gray-700">
+            <span class="text-sm font-medium">Add Keys Arrangement</span>
+            <button onclick="editorHideAddKeysModal()" class="text-gray-500 hover:text-white">&times;</button>
+        </div>
+        <div class="p-4 space-y-3">
+            <div>
+                <label class="text-xs font-medium text-gray-400 mb-1 block">Source File (Guitar Pro or MIDI)</label>
+                <input type="file" id="editor-add-keys-file" accept=".gp3,.gp4,.gp5,.gpx,.gp,.mid,.midi"
+                    onchange="editorKeysFileSelected(this)"
+                    class="w-full text-xs text-gray-400 file:mr-3 file:py-1 file:px-3 file:rounded file:border-0 file:text-xs file:bg-dark-600 file:text-gray-300 hover:file:bg-dark-500">
+                <p class="text-[11px] text-gray-600 mt-1">After import you can fine-tune note timing in the editor.</p>
+            </div>
+            <div id="editor-add-keys-tracks" class="hidden">
+                <label class="text-xs font-medium text-gray-400 mb-1 block">Select Keyboard Track</label>
+                <div id="editor-add-keys-track-list" class="space-y-1 max-h-40 overflow-y-auto bg-dark-800 rounded p-2"></div>
+            </div>
+            <button onclick="editorDoAddKeys()" id="editor-add-keys-go"
+                class="w-full px-4 py-2 bg-indigo-700 hover:bg-indigo-600 rounded-lg text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed" disabled>
+                Import Keys Track
+            </button>
+            <div id="editor-add-keys-status" class="text-xs text-gray-500"></div>
+        </div>
     </div>
 </div>
 

--- a/screen.js
+++ b/screen.js
@@ -1455,6 +1455,15 @@ function updateArrangementSelector() {
         sel.appendChild(opt);
     });
     sel.style.display = S.arrangements.length > 1 ? '' : 'none';
+    // Re-apply the active arrangement after the rebuild so callers that
+    // changed S.currentArr (e.g. + Keys / + Drums append, remove-arr)
+    // don't end up with a `<select>` snapped back to option 0 while the
+    // canvas edits the appended arrangement. Clamp to the valid range
+    // so an out-of-bounds S.currentArr doesn't render as a blank value.
+    if (S.arrangements.length > 0) {
+        const idx = Math.max(0, Math.min(S.currentArr || 0, S.arrangements.length - 1));
+        sel.value = String(idx);
+    }
 
     // Show "+ Drums" button when a session is active and no drums arrangement exists
     const hasDrums = S.arrangements.some(a => /^drums/i.test(a.name || ''));
@@ -2358,6 +2367,14 @@ window.editorDrumsGPSelected = async (input) => {
     const statusEl = document.getElementById('editor-add-drums-status');
     statusEl.textContent = 'Parsing GP file...';
 
+    // Drop any state from a previous successful parse so a later parse
+    // failure (or empty-tracks result) can't be silently committed via
+    // editorDoAddDrums using the older file's path.
+    _addDrumsGpPath = null;
+    _addDrumsTracks = [];
+    document.getElementById('editor-add-drums-go').disabled = true;
+    document.getElementById('editor-add-drums-tracks').classList.add('hidden');
+
     const formData = new FormData();
     formData.append('file', file);
 
@@ -2372,18 +2389,20 @@ window.editorDrumsGPSelected = async (input) => {
             return;
         }
 
-        _addDrumsGpPath = data.gp_path;
-        _addDrumsTracks = data.tracks;
-
         // Show only drum/percussion tracks (accept legacy is_percussion alias
         // from older slopsmith server.py revisions).
-        const drumTracks = data.tracks.filter(t => (t.is_drums || t.is_percussion) && t.notes > 0);
+        const tracks = data.tracks || [];
+        const drumTracks = tracks.filter(t => (t.is_drums || t.is_percussion) && t.notes > 0);
         if (drumTracks.length === 0) {
             statusEl.textContent = 'No drum/percussion tracks found in this file.';
-            document.getElementById('editor-add-drums-tracks').classList.add('hidden');
-            document.getElementById('editor-add-drums-go').disabled = true;
+            // Leave the cleared state from above in place — no usable
+            // tracks means editorDoAddDrums must remain disabled.
             return;
         }
+
+        // Only commit the new state once we know there's a usable track set.
+        _addDrumsGpPath = data.gp_path;
+        _addDrumsTracks = tracks;
 
         const listEl = document.getElementById('editor-add-drums-track-list');
         listEl.innerHTML = drumTracks.map(t => {
@@ -2502,6 +2521,14 @@ window.editorKeysFileSelected = async (input) => {
     const statusEl = document.getElementById('editor-add-keys-status');
     statusEl.textContent = 'Parsing ' + file.name + '...';
 
+    // Drop any state from a previous successful parse so a later parse
+    // failure (or empty-tracks result) can't be silently committed via
+    // editorDoAddKeys using the older file's path.
+    _addKeysSourcePath = null;
+    _addKeysSortedTracks = [];
+    document.getElementById('editor-add-keys-go').disabled = true;
+    document.getElementById('editor-add-keys-tracks').classList.add('hidden');
+
     const lower = file.name.toLowerCase();
     const isMidi = lower.endsWith('.mid') || lower.endsWith('.midi');
     _addKeysSourceFormat = isMidi ? 'midi' : 'gp';
@@ -2519,7 +2546,6 @@ window.editorKeysFileSelected = async (input) => {
             statusEl.textContent = 'Error: ' + data.error;
             return;
         }
-        _addKeysSourcePath = isMidi ? data.midi_path : data.gp_path;
         const tracks = data.tracks || [];
         // Surface piano-flagged tracks first; include all so the user can override.
         const sorted = tracks.slice().sort((a, b) => {
@@ -2528,17 +2554,21 @@ window.editorKeysFileSelected = async (input) => {
             if (ap !== bp) return ap - bp;
             return (b.notes || 0) - (a.notes || 0);
         });
+
+        if (sorted.length === 0) {
+            statusEl.textContent = 'No tracks found in this file.';
+            // Leave the cleared state from above in place — no usable
+            // tracks means editorDoAddKeys must remain disabled.
+            return;
+        }
+
+        // Only commit the new state once we know there's a usable track set.
+        _addKeysSourcePath = isMidi ? data.midi_path : data.gp_path;
         // Stash so editorDoAddKeys can resolve the radio value back to the
         // full track entry (it carries both `index` and `channel_filter`,
         // which can collide if a format-0 file produced multiple entries
         // sharing the same `index`).
         _addKeysSortedTracks = sorted;
-
-        if (sorted.length === 0) {
-            statusEl.textContent = 'No tracks found in this file.';
-            document.getElementById('editor-add-keys-tracks').classList.add('hidden');
-            return;
-        }
 
         const listEl = document.getElementById('editor-add-keys-track-list');
         const firstPianoPos = sorted.findIndex(t => t.is_piano);

--- a/screen.js
+++ b/screen.js
@@ -50,6 +50,7 @@ const KEYS_PATTERN = /^(keys|piano|keyboard|synth)/i;
 const S = {
     // Song data
     title: '', artist: '', sessionId: null, filename: '',
+    format: 'psarc',
     arrangements: [],
     currentArr: 0,
     beats: [], sections: [], duration: 0, offset: 0,
@@ -1420,6 +1421,11 @@ async function loadCDLC(filename) {
         S.cursorTime = 0;
         S.history = new EditHistory();
 
+        // Reset offset UI so _effectiveAudioOffset() doesn't carry over a
+        // delta from a previous session's sync nudge into this one.
+        const _offsetEl = document.getElementById('editor-offset');
+        if (_offsetEl) { _offsetEl.value = '0'; _offsetEl.dataset.applied = '0'; }
+
         // Flatten chord notes into main notes array for unified editing
         flattenChords();
         if (isKeysMode()) updatePianoRange();
@@ -2179,6 +2185,7 @@ window.editorDoCreate = async () => {
         S.artist = data.artist || '';
         S.filename = '';
         S.sessionId = data.session_id;
+        S.format = 'psarc';
         S.arrangements = data.arrangements || [];
         S.beats = data.beats || [];
         S.sections = data.sections || [];
@@ -2190,6 +2197,11 @@ window.editorDoCreate = async () => {
         S.cursorTime = 0;
         S.history = new EditHistory();
         S.createMode = true;
+
+        // Reset offset UI so _effectiveAudioOffset() doesn't carry over a
+        // delta from a previous session's sync nudge.
+        const _offsetElC = document.getElementById('editor-offset');
+        if (_offsetElC) { _offsetElC.value = '0'; _offsetElC.dataset.applied = '0'; }
 
         flattenChords();
         if (isKeysMode()) updatePianoRange();
@@ -2480,9 +2492,9 @@ window.editorDoAddDrums = async () => {
                 xml_path: data.xml_path,
             }),
         });
-        const addResult = await addResp.json();
-        if (addResult.error) {
-            statusEl.textContent = 'Error adding: ' + addResult.error;
+        const addResult = await addResp.json().catch(() => ({}));
+        if (!addResp.ok || addResult.error) {
+            statusEl.textContent = 'Error adding: ' + (addResult.error || addResp.status);
             goBtn.disabled = false;
             return;
         }
@@ -2657,7 +2669,7 @@ window.editorDoAddKeys = async () => {
         }
 
         // Register the new arrangement with the server-side session (no-op for sloppak).
-        await fetch('/api/plugins/editor/add-arrangement', {
+        const addResp = await fetch('/api/plugins/editor/add-arrangement', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
@@ -2666,6 +2678,12 @@ window.editorDoAddKeys = async () => {
                 xml_path: data.xml_path || '',
             }),
         });
+        const addData = await addResp.json().catch(() => ({}));
+        if (!addResp.ok || addData.error) {
+            statusEl.textContent = 'Error registering arrangement: ' + (addData.error || addResp.status);
+            goBtn.disabled = false;
+            return;
+        }
 
         // Append in-memory and switch to it
         S.arrangements.push(data.arrangement);

--- a/screen.js
+++ b/screen.js
@@ -36,7 +36,12 @@ const PIANO_OCTAVE_COLORS = [
 ];
 let PIANO_LANE_H = 10;  // pixels per MIDI semitone
 let pianoRange = { lo: 36, hi: 96 }; // MIDI range, updated per arrangement
-const KEYS_PATTERN = /^keys/i;
+// Names that should open in keys (piano-roll) editor mode. Keep this in
+// sync with the `+ Keys` button visibility test below — a name that's
+// considered "already a keys arrangement" must also open in keys mode,
+// otherwise sloppaks authored as "Piano"/"Keyboard"/"Synth" would render
+// as 6-string charts while the add-keys button is hidden.
+const KEYS_PATTERN = /^(keys|piano|keyboard|synth)/i;
 
 // ════════════════════════════════════════════════════════════════════
 // State
@@ -1473,7 +1478,9 @@ function updateArrangementSelector() {
     }
 
     // Show "+ Keys" button on sloppak sessions when no keys arrangement exists yet.
-    const hasKeys = S.arrangements.some(a => /keys|piano|keyboard|synth/i.test(a.name || ''));
+    // Use the same predicate as isKeysMode() so the set of names treated as
+    // existing keys charts is exactly the set that opens in keys editor mode.
+    const hasKeys = S.arrangements.some(a => KEYS_PATTERN.test(a.name || ''));
     const keysBtn = document.getElementById('editor-add-keys-btn');
     if (keysBtn) {
         keysBtn.classList.toggle('hidden', !S.sessionId || S.format !== 'sloppak' || hasKeys);
@@ -1742,6 +1749,18 @@ window.editorApplyOffset = (val) => {
     draw();
     setStatus(`Offset: ${offset >= 0 ? '+' : ''}${(offset * 1000).toFixed(0)}ms`);
 };
+
+// Effective audio offset to send when importing a new arrangement: the
+// song's loaded offset plus any UI-applied shift the user already made
+// via editorApplyOffset (which moves notes/beats but never updates
+// S.offset). Without this, a +Keys/+Drums import after a sync nudge
+// lands out of phase with the chart the user just realigned.
+function _effectiveAudioOffset() {
+    const base = Number(S.offset) || 0;
+    const el = document.getElementById('editor-offset');
+    const applied = el ? parseFloat(el.dataset.applied || '0') || 0 : 0;
+    return base + applied;
+}
 window.editorNudgeOffset = (delta) => {
     const el = document.getElementById('editor-offset');
     const current = parseFloat(el.value) || 0;
@@ -2441,7 +2460,7 @@ window.editorDoAddDrums = async () => {
             body: JSON.stringify({
                 gp_path: _addDrumsGpPath,
                 track_index: trackIndex,
-                audio_offset: S.offset || 0,
+                audio_offset: _effectiveAudioOffset(),
             }),
         });
         const data = await resp.json();
@@ -2620,10 +2639,11 @@ window.editorDoAddKeys = async () => {
         const url = _addKeysSourceFormat === 'midi'
             ? '/api/plugins/editor/import-keys-midi'
             : '/api/plugins/editor/import-keys';
+        const audioOffset = _effectiveAudioOffset();
         const body = _addKeysSourceFormat === 'midi'
-            ? { midi_path: _addKeysSourcePath, track_index: trackIndex, audio_offset: S.offset || 0,
+            ? { midi_path: _addKeysSourcePath, track_index: trackIndex, audio_offset: audioOffset,
                 channel_filter: channelFilter }
-            : { gp_path: _addKeysSourcePath, track_index: trackIndex, audio_offset: S.offset || 0 };
+            : { gp_path: _addKeysSourcePath, track_index: trackIndex, audio_offset: audioOffset };
         const resp = await fetch(url, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },

--- a/screen.js
+++ b/screen.js
@@ -1423,8 +1423,7 @@ async function loadCDLC(filename) {
 
         // Reset offset UI so _effectiveAudioOffset() doesn't carry over a
         // delta from a previous session's sync nudge into this one.
-        const _offsetEl = document.getElementById('editor-offset');
-        if (_offsetEl) { _offsetEl.value = '0'; _offsetEl.dataset.applied = '0'; }
+        _resetOffsetUI();
 
         // Flatten chord notes into main notes array for unified editing
         flattenChords();
@@ -1528,6 +1527,13 @@ function _editorEscHtml(s) {
         .replace(/>/g, '&gt;')
         .replace(/"/g, '&quot;')
         .replace(/'/g, '&#39;');
+}
+
+// Reset the offset input and its applied-delta dataset, called when loading
+// any session so _effectiveAudioOffset() doesn't carry over a previous nudge.
+function _resetOffsetUI() {
+    const el = document.getElementById('editor-offset');
+    if (el) { el.value = '0'; el.dataset.applied = '0'; }
 }
 
 function _normalizeSongList(raw) {
@@ -2200,8 +2206,7 @@ window.editorDoCreate = async () => {
 
         // Reset offset UI so _effectiveAudioOffset() doesn't carry over a
         // delta from a previous session's sync nudge.
-        const _offsetElC = document.getElementById('editor-offset');
-        if (_offsetElC) { _offsetElC.value = '0'; _offsetElC.dataset.applied = '0'; }
+        _resetOffsetUI();
 
         flattenChords();
         if (isKeysMode()) updatePianoRange();

--- a/screen.js
+++ b/screen.js
@@ -1544,12 +1544,12 @@ function _normalizeSongList(raw) {
         if (typeof item === 'string') {
             return {
                 filename: item,
-                format: item.endsWith('.sloppak') ? 'sloppak' : 'psarc',
+                format: item.toLowerCase().endsWith('.sloppak') ? 'sloppak' : 'psarc',
             };
         }
         const filename = String(item?.filename ?? '');
         const format = String(item?.format
-            ?? (filename.endsWith('.sloppak') ? 'sloppak' : 'psarc'));
+            ?? (filename.toLowerCase().endsWith('.sloppak') ? 'sloppak' : 'psarc'));
         return { filename, format };
     });
 }
@@ -2379,11 +2379,9 @@ window.editorRemoveArrangement = async () => {
 // ════════════════════════════════════════════════════════════════════
 
 let _addDrumsGpPath = null;
-let _addDrumsTracks = [];
 
 window.editorShowAddDrumsModal = () => {
     _addDrumsGpPath = null;
-    _addDrumsTracks = [];
     document.getElementById('editor-add-drums-modal').classList.remove('hidden');
     document.getElementById('editor-add-drums-tracks').classList.add('hidden');
     document.getElementById('editor-add-drums-go').disabled = true;
@@ -2407,7 +2405,6 @@ window.editorDrumsGPSelected = async (input) => {
     // failure (or empty-tracks result) can't be silently committed via
     // editorDoAddDrums using the older file's path.
     _addDrumsGpPath = null;
-    _addDrumsTracks = [];
     document.getElementById('editor-add-drums-go').disabled = true;
     document.getElementById('editor-add-drums-tracks').classList.add('hidden');
 
@@ -2438,7 +2435,6 @@ window.editorDrumsGPSelected = async (input) => {
 
         // Only commit the new state once we know there's a usable track set.
         _addDrumsGpPath = data.gp_path;
-        _addDrumsTracks = tracks;
 
         const listEl = document.getElementById('editor-add-drums-track-list');
         listEl.innerHTML = drumTracks.map(t => {

--- a/screen.js
+++ b/screen.js
@@ -1497,9 +1497,21 @@ async function showLoadModal() {
     document.getElementById('editor-load-search').focus();
 }
 
+// Escape a string for safe interpolation into innerHTML. Covers the five
+// chars that matter for HTML context (& must be first to avoid double-escape).
+function _editorEscHtml(s) {
+    return String(s ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
 function _normalizeSongList(raw) {
     // Backend now returns [{filename, format}] objects. Older deployments
-    // may still return plain string filenames — normalize either shape.
+    // may still return plain string filenames — normalize either shape and
+    // default missing fields so callers can rely on a consistent shape.
     return (raw || []).map(item => {
         if (typeof item === 'string') {
             return {
@@ -1507,25 +1519,42 @@ function _normalizeSongList(raw) {
                 format: item.endsWith('.sloppak') ? 'sloppak' : 'psarc',
             };
         }
-        return item;
+        const filename = String(item?.filename ?? '');
+        const format = String(item?.format
+            ?? (filename.endsWith('.sloppak') ? 'sloppak' : 'psarc'));
+        return { filename, format };
     });
 }
 
 function renderSongList(files) {
     const list = document.getElementById('editor-load-list');
     files = _normalizeSongList(files);
+    list.innerHTML = '';
     if (!files.length) {
         list.innerHTML = '<div class="text-xs text-gray-500 p-2">No CDLC files found</div>';
         return;
     }
-    list.innerHTML = files.map(f => {
-        const safe = f.filename.replace(/'/g, "\\'");
+    // Build the DOM imperatively so filenames never reach innerHTML.
+    for (const f of files) {
+        const btn = document.createElement('button');
+        btn.className = 'w-full text-left px-3 py-1.5 text-xs text-gray-300 hover:bg-dark-500 rounded flex items-center gap-2';
+        btn.addEventListener('click', () => editorLoadFile(f.filename));
+
+        const name = document.createElement('span');
+        name.className = 'flex-1 truncate';
+        name.textContent = f.filename;
+        btn.appendChild(name);
+
+        const badge = document.createElement('span');
         const badgeColor = f.format === 'sloppak'
             ? 'bg-green-900/40 text-green-300'
             : 'bg-blue-900/40 text-blue-300';
-        const badge = `<span class="px-1.5 py-0.5 rounded text-[10px] uppercase tracking-wide ${badgeColor}">${f.format}</span>`;
-        return `<button onclick="editorLoadFile('${safe}')" class="w-full text-left px-3 py-1.5 text-xs text-gray-300 hover:bg-dark-500 rounded flex items-center gap-2"><span class="flex-1 truncate">${f.filename}</span>${badge}</button>`;
-    }).join('');
+        badge.className = `px-1.5 py-0.5 rounded text-[10px] uppercase tracking-wide ${badgeColor}`;
+        badge.textContent = f.format;
+        btn.appendChild(badge);
+
+        list.appendChild(btn);
+    }
 }
 
 function filterSongs(q) {
@@ -1971,15 +2000,17 @@ window.editorGPFileSelected = async (input) => {
         // Show track list
         const listEl = document.getElementById('editor-create-track-list');
         listEl.innerHTML = data.tracks.map(t => {
-            const badge = t.is_drums ? ' (drums)'
+            const isDrums = !!(t.is_drums || t.is_percussion);
+            const badge = isDrums ? ' (drums)'
                 : t.is_piano ? ' (keys)'
                 : '';
             const disabled = t.notes === 0;
+            const safeName = _editorEscHtml(t.name);
             return `<label class="flex items-center gap-2 text-xs text-gray-300 py-0.5">
                 <input type="checkbox" value="${t.index}" checked
                     class="accent-accent" ${disabled ? 'disabled' : ''}>
-                <span class="${t.is_drums ? 'text-red-300' : t.is_piano ? 'text-indigo-300' : ''}">${t.name}</span>
-                <span class="text-gray-600">${t.strings}str, ${t.notes} notes${badge}</span>
+                <span class="${isDrums ? 'text-red-300' : t.is_piano ? 'text-indigo-300' : ''}">${safeName}</span>
+                <span class="text-gray-600">${Number(t.strings) || 0}str, ${Number(t.notes) || 0} notes${badge}</span>
             </label>`;
         }).join('');
         document.getElementById('editor-create-tracks').classList.remove('hidden');
@@ -2324,8 +2355,9 @@ window.editorDrumsGPSelected = async (input) => {
         _addDrumsGpPath = data.gp_path;
         _addDrumsTracks = data.tracks;
 
-        // Show only drum/percussion tracks
-        const drumTracks = data.tracks.filter(t => t.is_drums && t.notes > 0);
+        // Show only drum/percussion tracks (accept legacy is_percussion alias
+        // from older slopsmith server.py revisions).
+        const drumTracks = data.tracks.filter(t => (t.is_drums || t.is_percussion) && t.notes > 0);
         if (drumTracks.length === 0) {
             statusEl.textContent = 'No drum/percussion tracks found in this file.';
             document.getElementById('editor-add-drums-tracks').classList.add('hidden');
@@ -2334,13 +2366,14 @@ window.editorDrumsGPSelected = async (input) => {
         }
 
         const listEl = document.getElementById('editor-add-drums-track-list');
-        listEl.innerHTML = drumTracks.map(t =>
-            `<label class="flex items-center gap-2 text-xs text-gray-300 py-0.5">
+        listEl.innerHTML = drumTracks.map(t => {
+            const safeName = _editorEscHtml(t.name);
+            return `<label class="flex items-center gap-2 text-xs text-gray-300 py-0.5">
                 <input type="radio" name="drums-track" value="${t.index}" checked class="accent-red-500">
-                <span class="text-red-300">${t.name}</span>
-                <span class="text-gray-600">${t.notes} notes</span>
-            </label>`
-        ).join('');
+                <span class="text-red-300">${safeName}</span>
+                <span class="text-gray-600">${Number(t.notes) || 0} notes</span>
+            </label>`;
+        }).join('');
         document.getElementById('editor-add-drums-tracks').classList.remove('hidden');
         document.getElementById('editor-add-drums-go').disabled = false;
         statusEl.textContent = `Found ${drumTracks.length} drum track(s).`;
@@ -2482,13 +2515,15 @@ window.editorKeysFileSelected = async (input) => {
         const defaultIdx = firstPianoIdx >= 0 ? sorted[firstPianoIdx].index : sorted[0].index;
         listEl.innerHTML = sorted.map(t => {
             const checked = t.index === defaultIdx ? 'checked' : '';
+            const isDrums = !!(t.is_drums || t.is_percussion);
             const flag = t.is_piano ? '<span class="text-indigo-300">[keys]</span>' : '';
-            const drumsTag = t.is_drums ? '<span class="text-red-400">[drums]</span>' : '';
+            const drumsTag = isDrums ? '<span class="text-red-400">[drums]</span>' : '';
+            const safeName = _editorEscHtml(t.name || '') || ('Track ' + t.index);
             return `<label class="flex items-center gap-2 text-xs text-gray-300 py-0.5">
                 <input type="radio" name="keys-track" value="${t.index}" ${checked} class="accent-indigo-500">
-                <span class="text-gray-200">${(t.name || '').replace(/</g, '&lt;') || ('Track ' + t.index)}</span>
+                <span class="text-gray-200">${safeName}</span>
                 ${flag} ${drumsTag}
-                <span class="text-gray-600 ml-auto">${t.notes || 0} notes</span>
+                <span class="text-gray-600 ml-auto">${Number(t.notes) || 0} notes</span>
             </label>`;
         }).join('');
         document.getElementById('editor-add-keys-tracks').classList.remove('hidden');

--- a/screen.js
+++ b/screen.js
@@ -2600,7 +2600,7 @@ window.editorKeysFileSelected = async (input) => {
             const isDrums = !!(t.is_drums || t.is_percussion);
             const flag = t.is_piano ? '<span class="text-indigo-300">[keys]</span>' : '';
             const drumsTag = isDrums ? '<span class="text-red-400">[drums]</span>' : '';
-            const safeName = _editorEscHtml(t.name || '') || ('Track ' + t.index);
+            const safeName = _editorEscHtml(t.name || '') || _editorEscHtml('Track ' + t.index);
             return `<label class="flex items-center gap-2 text-xs text-gray-300 py-0.5">
                 <input type="radio" name="keys-track" value="${pos}" ${checked} class="accent-indigo-500">
                 <span class="text-gray-200">${safeName}</span>

--- a/screen.js
+++ b/screen.js
@@ -202,7 +202,10 @@ function reconstructChords() {
     }
     const newNotes = [];
     const newChords = [];
-    const chordTemplates = arr.chord_templates || [];
+    // Always rebuild chord_templates from scratch so repeated saves don't
+    // accumulate duplicate entries (flattenChords has already emptied
+    // arr.chords, so the old templates are no longer referenced).
+    const chordTemplates = [];
     const templateMap = {};
 
     for (const key of Object.keys(byTime).sort((a, b) => parseFloat(a) - parseFloat(b))) {
@@ -1472,6 +1475,7 @@ function updateArrangementSelector() {
     // so an out-of-bounds S.currentArr doesn't render as a blank value.
     if (S.arrangements.length > 0) {
         const idx = Math.max(0, Math.min(S.currentArr || 0, S.arrangements.length - 1));
+        S.currentArr = idx;
         sel.value = String(idx);
     }
 

--- a/screen.js
+++ b/screen.js
@@ -1403,6 +1403,7 @@ async function loadCDLC(filename) {
         S.artist = data.artist || '';
         S.filename = filename;
         S.sessionId = data.session_id;
+        S.format = data.format || 'psarc';
         S.arrangements = data.arrangements || [];
         S.beats = data.beats || [];
         S.sections = data.sections || [];
@@ -1454,6 +1455,26 @@ function updateArrangementSelector() {
         sel.appendChild(opt);
     });
     sel.style.display = S.arrangements.length > 1 ? '' : 'none';
+
+    // Show "+ Drums" button when a session is active and no drums arrangement exists
+    const hasDrums = S.arrangements.some(a => /^drums/i.test(a.name || ''));
+    const drumsBtn = document.getElementById('editor-add-drums-btn');
+    if (drumsBtn) {
+        drumsBtn.classList.toggle('hidden', !S.sessionId || hasDrums);
+    }
+
+    // Show "+ Keys" button on sloppak sessions when no keys arrangement exists yet.
+    const hasKeys = S.arrangements.some(a => /keys|piano|keyboard|synth/i.test(a.name || ''));
+    const keysBtn = document.getElementById('editor-add-keys-btn');
+    if (keysBtn) {
+        keysBtn.classList.toggle('hidden', !S.sessionId || S.format !== 'sloppak' || hasKeys);
+    }
+
+    // Show remove button when there are multiple arrangements
+    const removeBtn = document.getElementById('editor-remove-arr-btn');
+    if (removeBtn) {
+        removeBtn.classList.toggle('hidden', S.arrangements.length <= 1);
+    }
 }
 
 // ════════════════════════════════════════════════════════════════════
@@ -1476,21 +1497,42 @@ async function showLoadModal() {
     document.getElementById('editor-load-search').focus();
 }
 
+function _normalizeSongList(raw) {
+    // Backend now returns [{filename, format}] objects. Older deployments
+    // may still return plain string filenames — normalize either shape.
+    return (raw || []).map(item => {
+        if (typeof item === 'string') {
+            return {
+                filename: item,
+                format: item.endsWith('.sloppak') ? 'sloppak' : 'psarc',
+            };
+        }
+        return item;
+    });
+}
+
 function renderSongList(files) {
     const list = document.getElementById('editor-load-list');
+    files = _normalizeSongList(files);
     if (!files.length) {
         list.innerHTML = '<div class="text-xs text-gray-500 p-2">No CDLC files found</div>';
         return;
     }
-    list.innerHTML = files.map(f =>
-        `<button onclick="editorLoadFile('${f.replace(/'/g, "\\'")}')" class="w-full text-left px-3 py-1.5 text-xs text-gray-300 hover:bg-dark-500 rounded truncate">${f}</button>`
-    ).join('');
+    list.innerHTML = files.map(f => {
+        const safe = f.filename.replace(/'/g, "\\'");
+        const badgeColor = f.format === 'sloppak'
+            ? 'bg-green-900/40 text-green-300'
+            : 'bg-blue-900/40 text-blue-300';
+        const badge = `<span class="px-1.5 py-0.5 rounded text-[10px] uppercase tracking-wide ${badgeColor}">${f.format}</span>`;
+        return `<button onclick="editorLoadFile('${safe}')" class="w-full text-left px-3 py-1.5 text-xs text-gray-300 hover:bg-dark-500 rounded flex items-center gap-2"><span class="flex-1 truncate">${f.filename}</span>${badge}</button>`;
+    }).join('');
 }
 
 function filterSongs(q) {
     if (!S.songsList) return;
+    const list = _normalizeSongList(S.songsList);
     const low = q.toLowerCase();
-    const filtered = S.songsList.filter(f => f.toLowerCase().includes(low));
+    const filtered = list.filter(f => f.filename.toLowerCase().includes(low));
     renderSongList(filtered);
 }
 
@@ -1506,19 +1548,29 @@ async function saveCDLC() {
     reconstructChords();
 
     const arr = S.arrangements[S.currentArr];
+    const body = {
+        session_id: S.sessionId,
+        arrangement_index: S.currentArr,
+        notes: arr.notes,
+        chords: arr.chords,
+        chord_templates: arr.chord_templates,
+        beats: S.beats,
+        sections: S.sections,
+    };
+    // Sloppak: send the full arrangement snapshot so adds/reorders persist
+    // and the per-arrangement files all stay current.
+    if (S.format === 'sloppak') {
+        body.arrangements = S.arrangements;
+        body.metadata = {
+            title: S.title,
+            artist: S.artist,
+        };
+    }
     try {
         const resp = await fetch('/api/plugins/editor/save', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-                session_id: S.sessionId,
-                arrangement_index: S.currentArr,
-                notes: arr.notes,
-                chords: arr.chords,
-                chord_templates: arr.chord_templates,
-                beats: S.beats,
-                sections: S.sections,
-            }),
+            body: JSON.stringify(body),
         });
         const data = await resp.json();
         if (data.error) { setStatus('Save error: ' + data.error); return; }
@@ -1919,14 +1971,14 @@ window.editorGPFileSelected = async (input) => {
         // Show track list
         const listEl = document.getElementById('editor-create-track-list');
         listEl.innerHTML = data.tracks.map(t => {
-            const badge = t.is_percussion ? ' (percussion)'
+            const badge = t.is_drums ? ' (drums)'
                 : t.is_piano ? ' (keys)'
                 : '';
-            const disabled = t.is_percussion || t.notes === 0;
+            const disabled = t.notes === 0;
             return `<label class="flex items-center gap-2 text-xs text-gray-300 py-0.5">
                 <input type="checkbox" value="${t.index}" checked
                     class="accent-accent" ${disabled ? 'disabled' : ''}>
-                <span class="${t.is_percussion ? 'text-gray-600' : t.is_piano ? 'text-indigo-300' : ''}">${t.name}</span>
+                <span class="${t.is_drums ? 'text-red-300' : t.is_piano ? 'text-indigo-300' : ''}">${t.name}</span>
                 <span class="text-gray-600">${t.strings}str, ${t.notes} notes${badge}</span>
             </label>`;
         }).join('');
@@ -2181,6 +2233,334 @@ function init() {
 
     draw();
 }
+
+// ════════════════════════════════════════════════════════════════════
+// Remove arrangement
+// ════════════════════════════════════════════════════════════════════
+
+window.editorRemoveArrangement = async () => {
+    if (S.arrangements.length <= 1) return;
+    const removeIdx = S.currentArr;
+    const arr = S.arrangements[removeIdx];
+    if (!confirm(`Remove "${arr.name}" arrangement?`)) return;
+
+    // Remove from backend first
+    if (S.sessionId) {
+        try {
+            const resp = await fetch('/api/plugins/editor/remove-arrangement', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    session_id: S.sessionId,
+                    arrangement_index: removeIdx,
+                }),
+            });
+            const result = await resp.json();
+            if (result.error) {
+                setStatus('Remove failed: ' + result.error);
+                return;
+            }
+        } catch (e) {
+            setStatus('Remove failed: ' + e.message);
+            return;
+        }
+    }
+
+    // Then update frontend state
+    S.arrangements.splice(removeIdx, 1);
+    S.currentArr = Math.min(removeIdx, S.arrangements.length - 1);
+    S.sel.clear();
+    flattenChords();
+    updateArrangementSelector();
+    document.getElementById('editor-arrangement').value = S.currentArr;
+    updateStatus();
+    draw();
+    setStatus(`Removed "${arr.name}" arrangement`);
+};
+
+// ════════════════════════════════════════════════════════════════════
+// Add Drums arrangement from GP file
+// ════════════════════════════════════════════════════════════════════
+
+let _addDrumsGpPath = null;
+let _addDrumsTracks = [];
+
+window.editorShowAddDrumsModal = () => {
+    _addDrumsGpPath = null;
+    _addDrumsTracks = [];
+    document.getElementById('editor-add-drums-modal').classList.remove('hidden');
+    document.getElementById('editor-add-drums-tracks').classList.add('hidden');
+    document.getElementById('editor-add-drums-go').disabled = true;
+    document.getElementById('editor-add-drums-status').textContent = '';
+    const fileInput = document.getElementById('editor-add-drums-gp');
+    if (fileInput) fileInput.value = '';
+};
+
+window.editorHideAddDrumsModal = () => {
+    document.getElementById('editor-add-drums-modal').classList.add('hidden');
+};
+
+window.editorDrumsGPSelected = async (input) => {
+    const file = input.files[0];
+    if (!file) return;
+
+    const statusEl = document.getElementById('editor-add-drums-status');
+    statusEl.textContent = 'Parsing GP file...';
+
+    const formData = new FormData();
+    formData.append('file', file);
+
+    try {
+        const resp = await fetch('/api/plugins/editor/import-gp', {
+            method: 'POST',
+            body: formData,
+        });
+        const data = await resp.json();
+        if (data.error) {
+            statusEl.textContent = 'Error: ' + data.error;
+            return;
+        }
+
+        _addDrumsGpPath = data.gp_path;
+        _addDrumsTracks = data.tracks;
+
+        // Show only drum/percussion tracks
+        const drumTracks = data.tracks.filter(t => t.is_drums && t.notes > 0);
+        if (drumTracks.length === 0) {
+            statusEl.textContent = 'No drum/percussion tracks found in this file.';
+            document.getElementById('editor-add-drums-tracks').classList.add('hidden');
+            document.getElementById('editor-add-drums-go').disabled = true;
+            return;
+        }
+
+        const listEl = document.getElementById('editor-add-drums-track-list');
+        listEl.innerHTML = drumTracks.map(t =>
+            `<label class="flex items-center gap-2 text-xs text-gray-300 py-0.5">
+                <input type="radio" name="drums-track" value="${t.index}" checked class="accent-red-500">
+                <span class="text-red-300">${t.name}</span>
+                <span class="text-gray-600">${t.notes} notes</span>
+            </label>`
+        ).join('');
+        document.getElementById('editor-add-drums-tracks').classList.remove('hidden');
+        document.getElementById('editor-add-drums-go').disabled = false;
+        statusEl.textContent = `Found ${drumTracks.length} drum track(s).`;
+    } catch (e) {
+        statusEl.textContent = 'Failed: ' + e.message;
+    }
+};
+
+window.editorDoAddDrums = async () => {
+    if (!_addDrumsGpPath || !S.sessionId) return;
+
+    const statusEl = document.getElementById('editor-add-drums-status');
+    const goBtn = document.getElementById('editor-add-drums-go');
+    goBtn.disabled = true;
+    statusEl.textContent = 'Importing drum track...';
+
+    // Get selected track index
+    const radio = document.querySelector('input[name="drums-track"]:checked');
+    const trackIndex = radio ? parseInt(radio.value) : 0;
+
+    try {
+        // Import the drum track
+        const resp = await fetch('/api/plugins/editor/import-drums', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                gp_path: _addDrumsGpPath,
+                track_index: trackIndex,
+                audio_offset: S.offset || 0,
+            }),
+        });
+        const data = await resp.json();
+        if (data.error) {
+            statusEl.textContent = 'Error: ' + data.error;
+            goBtn.disabled = false;
+            return;
+        }
+
+        // Add to current session
+        const addResp = await fetch('/api/plugins/editor/add-arrangement', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                session_id: S.sessionId,
+                arrangement: data.arrangement,
+                xml_path: data.xml_path,
+            }),
+        });
+        const addResult = await addResp.json();
+        if (addResult.error) {
+            statusEl.textContent = 'Error adding: ' + addResult.error;
+            goBtn.disabled = false;
+            return;
+        }
+
+        // Add the arrangement to local state
+        S.arrangements.push(data.arrangement);
+        S.currentArr = S.arrangements.length - 1;
+        const sel = document.getElementById('editor-arrangement');
+        sel.value = S.currentArr;
+
+        flattenChords();
+        updateArrangementSelector();
+        updateStatus();
+        draw();
+
+        editorHideAddDrumsModal();
+        setStatus('Added Drums arrangement (' + data.arrangement.notes.length + ' notes)');
+    } catch (e) {
+        statusEl.textContent = 'Failed: ' + e.message;
+        goBtn.disabled = false;
+    }
+};
+
+// ════════════════════════════════════════════════════════════════════
+// Add Keys arrangement (sloppak — GP or MIDI source)
+// ════════════════════════════════════════════════════════════════════
+
+let _addKeysSourcePath = null;       // server-side path to the uploaded file
+let _addKeysSourceFormat = null;     // 'gp' or 'midi'
+
+window.editorShowAddKeysModal = () => {
+    if (S.format !== 'sloppak') return;
+    document.getElementById('editor-add-keys-modal').classList.remove('hidden');
+    document.getElementById('editor-add-keys-tracks').classList.add('hidden');
+    document.getElementById('editor-add-keys-go').disabled = true;
+    document.getElementById('editor-add-keys-status').textContent = '';
+    const fi = document.getElementById('editor-add-keys-file');
+    if (fi) fi.value = '';
+    _addKeysSourcePath = null;
+    _addKeysSourceFormat = null;
+};
+
+window.editorHideAddKeysModal = () => {
+    document.getElementById('editor-add-keys-modal').classList.add('hidden');
+};
+
+window.editorKeysFileSelected = async (input) => {
+    const file = input.files && input.files[0];
+    if (!file) return;
+    const statusEl = document.getElementById('editor-add-keys-status');
+    statusEl.textContent = 'Parsing ' + file.name + '...';
+
+    const lower = file.name.toLowerCase();
+    const isMidi = lower.endsWith('.mid') || lower.endsWith('.midi');
+    _addKeysSourceFormat = isMidi ? 'midi' : 'gp';
+
+    const fd = new FormData();
+    fd.append('file', file);
+
+    try {
+        const url = isMidi
+            ? '/api/plugins/editor/import-midi'
+            : '/api/plugins/editor/import-gp';
+        const resp = await fetch(url, { method: 'POST', body: fd });
+        const data = await resp.json();
+        if (data.error) {
+            statusEl.textContent = 'Error: ' + data.error;
+            return;
+        }
+        _addKeysSourcePath = isMidi ? data.midi_path : data.gp_path;
+        const tracks = data.tracks || [];
+        // Surface piano-flagged tracks first; include all so the user can override.
+        const sorted = tracks.slice().sort((a, b) => {
+            const ap = (a.is_piano ? 0 : 1);
+            const bp = (b.is_piano ? 0 : 1);
+            if (ap !== bp) return ap - bp;
+            return (b.notes || 0) - (a.notes || 0);
+        });
+
+        if (sorted.length === 0) {
+            statusEl.textContent = 'No tracks found in this file.';
+            document.getElementById('editor-add-keys-tracks').classList.add('hidden');
+            return;
+        }
+
+        const listEl = document.getElementById('editor-add-keys-track-list');
+        const firstPianoIdx = sorted.findIndex(t => t.is_piano);
+        const defaultIdx = firstPianoIdx >= 0 ? sorted[firstPianoIdx].index : sorted[0].index;
+        listEl.innerHTML = sorted.map(t => {
+            const checked = t.index === defaultIdx ? 'checked' : '';
+            const flag = t.is_piano ? '<span class="text-indigo-300">[keys]</span>' : '';
+            const drumsTag = t.is_drums ? '<span class="text-red-400">[drums]</span>' : '';
+            return `<label class="flex items-center gap-2 text-xs text-gray-300 py-0.5">
+                <input type="radio" name="keys-track" value="${t.index}" ${checked} class="accent-indigo-500">
+                <span class="text-gray-200">${(t.name || '').replace(/</g, '&lt;') || ('Track ' + t.index)}</span>
+                ${flag} ${drumsTag}
+                <span class="text-gray-600 ml-auto">${t.notes || 0} notes</span>
+            </label>`;
+        }).join('');
+        document.getElementById('editor-add-keys-tracks').classList.remove('hidden');
+        document.getElementById('editor-add-keys-go').disabled = false;
+        const found = sorted.filter(t => t.is_piano).length;
+        statusEl.textContent = found > 0
+            ? `Found ${found} keyboard track(s). Pick one.`
+            : `No tracks auto-flagged as keyboard — pick one manually.`;
+    } catch (e) {
+        statusEl.textContent = 'Failed: ' + e.message;
+    }
+};
+
+window.editorDoAddKeys = async () => {
+    if (!_addKeysSourcePath || !S.sessionId) return;
+    const statusEl = document.getElementById('editor-add-keys-status');
+    const goBtn = document.getElementById('editor-add-keys-go');
+    goBtn.disabled = true;
+    statusEl.textContent = 'Importing keys track...';
+
+    const radio = document.querySelector('input[name="keys-track"]:checked');
+    const trackIndex = radio ? parseInt(radio.value) : 0;
+
+    try {
+        const url = _addKeysSourceFormat === 'midi'
+            ? '/api/plugins/editor/import-keys-midi'
+            : '/api/plugins/editor/import-keys';
+        const body = _addKeysSourceFormat === 'midi'
+            ? { midi_path: _addKeysSourcePath, track_index: trackIndex, audio_offset: S.offset || 0 }
+            : { gp_path: _addKeysSourcePath, track_index: trackIndex, audio_offset: S.offset || 0 };
+        const resp = await fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        });
+        const data = await resp.json();
+        if (data.error) {
+            statusEl.textContent = 'Error: ' + data.error;
+            goBtn.disabled = false;
+            return;
+        }
+
+        // Register the new arrangement with the server-side session (no-op for sloppak).
+        await fetch('/api/plugins/editor/add-arrangement', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                session_id: S.sessionId,
+                arrangement: data.arrangement,
+                xml_path: data.xml_path || '',
+            }),
+        });
+
+        // Append in-memory and switch to it
+        S.arrangements.push(data.arrangement);
+        S.currentArr = S.arrangements.length - 1;
+        const sel = document.getElementById('editor-arrangement');
+        sel.value = S.currentArr;
+
+        flattenChords();
+        if (typeof updatePianoRange === 'function') updatePianoRange();
+        updateArrangementSelector();
+        updateStatus();
+        draw();
+
+        editorHideAddKeysModal();
+        setStatus('Added Keys arrangement (' + data.arrangement.notes.length + ' notes). Save to commit.');
+    } catch (e) {
+        statusEl.textContent = 'Failed: ' + e.message;
+        goBtn.disabled = false;
+    }
+};
 
 // Run init after DOM is ready
 if (document.getElementById('editor-canvas')) {

--- a/screen.js
+++ b/screen.js
@@ -1573,8 +1573,28 @@ async function saveCDLC() {
     if (!S.sessionId) return;
     setStatus('Saving...');
 
-    // Reconstruct chords from notes at the same time position
-    reconstructChords();
+    // Sloppak save sends the full S.arrangements snapshot, so every
+    // arrangement (not just the active one) needs its chords reconstructed.
+    // Tab-switching only flattens the new currentArr — non-current
+    // arrangements may be in any of three states: never flattened
+    // (chords:[chord_groups], notes:[regular notes only]), flattened-and-
+    // -unreconstructed (chords:[], notes:[regular + flattened chord notes
+    // tagged with _fromChord]), or already round-tripped through both.
+    // Running flatten→reconstruct on every arrangement normalises them all:
+    // flatten is a no-op on already-flattened ones, and reconstruct rebuilds
+    // the chord groups by time. PSARC saves only emit S.currentArr so they
+    // keep the existing single-pass call.
+    const savedArr = S.currentArr;
+    if (S.format === 'sloppak') {
+        for (let i = 0; i < S.arrangements.length; i++) {
+            S.currentArr = i;
+            flattenChords();
+            reconstructChords();
+        }
+        S.currentArr = savedArr;
+    } else {
+        reconstructChords();
+    }
 
     const arr = S.arrangements[S.currentArr];
     const body = {
@@ -2454,6 +2474,11 @@ window.editorDoAddDrums = async () => {
 
 let _addKeysSourcePath = null;       // server-side path to the uploaded file
 let _addKeysSourceFormat = null;     // 'gp' or 'midi'
+// Cached after a successful list-tracks call; the keys-track radio value
+// is an index into this array, not the track's MIDI/GP index, because
+// format-0 channel splits can yield multiple picker entries sharing the
+// same MIDI `index`.
+let _addKeysSortedTracks = [];
 
 window.editorShowAddKeysModal = () => {
     if (S.format !== 'sloppak') return;
@@ -2503,6 +2528,11 @@ window.editorKeysFileSelected = async (input) => {
             if (ap !== bp) return ap - bp;
             return (b.notes || 0) - (a.notes || 0);
         });
+        // Stash so editorDoAddKeys can resolve the radio value back to the
+        // full track entry (it carries both `index` and `channel_filter`,
+        // which can collide if a format-0 file produced multiple entries
+        // sharing the same `index`).
+        _addKeysSortedTracks = sorted;
 
         if (sorted.length === 0) {
             statusEl.textContent = 'No tracks found in this file.';
@@ -2511,16 +2541,19 @@ window.editorKeysFileSelected = async (input) => {
         }
 
         const listEl = document.getElementById('editor-add-keys-track-list');
-        const firstPianoIdx = sorted.findIndex(t => t.is_piano);
-        const defaultIdx = firstPianoIdx >= 0 ? sorted[firstPianoIdx].index : sorted[0].index;
-        listEl.innerHTML = sorted.map(t => {
-            const checked = t.index === defaultIdx ? 'checked' : '';
+        const firstPianoPos = sorted.findIndex(t => t.is_piano);
+        const defaultPos = firstPianoPos >= 0 ? firstPianoPos : 0;
+        // Radio value is the position in `sorted` (not t.index) because
+        // format-0 channel splits produce multiple entries that share the
+        // same MIDI track_index — we need a unique key.
+        listEl.innerHTML = sorted.map((t, pos) => {
+            const checked = pos === defaultPos ? 'checked' : '';
             const isDrums = !!(t.is_drums || t.is_percussion);
             const flag = t.is_piano ? '<span class="text-indigo-300">[keys]</span>' : '';
             const drumsTag = isDrums ? '<span class="text-red-400">[drums]</span>' : '';
             const safeName = _editorEscHtml(t.name || '') || ('Track ' + t.index);
             return `<label class="flex items-center gap-2 text-xs text-gray-300 py-0.5">
-                <input type="radio" name="keys-track" value="${t.index}" ${checked} class="accent-indigo-500">
+                <input type="radio" name="keys-track" value="${pos}" ${checked} class="accent-indigo-500">
                 <span class="text-gray-200">${safeName}</span>
                 ${flag} ${drumsTag}
                 <span class="text-gray-600 ml-auto">${Number(t.notes) || 0} notes</span>
@@ -2545,14 +2578,21 @@ window.editorDoAddKeys = async () => {
     statusEl.textContent = 'Importing keys track...';
 
     const radio = document.querySelector('input[name="keys-track"]:checked');
-    const trackIndex = radio ? parseInt(radio.value) : 0;
+    // Radio value is a position in _addKeysSortedTracks; resolve it back to
+    // the full entry so we can pull both `index` and `channel_filter`.
+    const pos = radio ? parseInt(radio.value) : 0;
+    const picked = _addKeysSortedTracks[pos] || _addKeysSortedTracks[0];
+    if (!picked) { statusEl.textContent = 'No track selected.'; goBtn.disabled = false; return; }
+    const trackIndex = Number(picked.index) || 0;
+    const channelFilter = (picked.channel_filter == null) ? null : Number(picked.channel_filter);
 
     try {
         const url = _addKeysSourceFormat === 'midi'
             ? '/api/plugins/editor/import-keys-midi'
             : '/api/plugins/editor/import-keys';
         const body = _addKeysSourceFormat === 'midi'
-            ? { midi_path: _addKeysSourcePath, track_index: trackIndex, audio_offset: S.offset || 0 }
+            ? { midi_path: _addKeysSourcePath, track_index: trackIndex, audio_offset: S.offset || 0,
+                channel_filter: channelFilter }
             : { gp_path: _addKeysSourcePath, track_index: trackIndex, audio_offset: S.offset || 0 };
         const resp = await fetch(url, {
             method: 'POST',


### PR DESCRIPTION
Pairs with [slopsmith PR](https://github.com/byrongamatos/slopsmith/pulls?q=is%3Apr+is%3Aopen+sloppak-edit-support) which adds the server-side `_get_dlc_dir()` fix, `lib/midi_import.py`, and the `mido` dependency this plugin uses.

## Summary

Extends the arrangement editor to fully support `.sloppak` files alongside PSARC.

- **Song picker** lists `.sloppak` files with a format badge.
- **Loading** a sloppak resolves it via `lib.sloppak.load_song`, mounts the unpacked cache dir as the editor's session dir, and exposes the manifest's `full` (or first) stem as the editor's audio source.
- **Saving** writes wire-format JSON arrangements via short field names (matching `docs/sloppak-spec.md` from #106), updates `manifest.yaml` in place, re-zips the dir into the original `.sloppak` filename, and backs up to `.bak`. Both single-arrangement and full-snapshot save shapes are supported.
- **Add-arrangement** and **remove-arrangement** become in-memory ops for sloppak sessions; the next save commits the snapshot and drops orphaned arrangement JSONs from the working dir.
- **+ Keys** button (sloppak only, when no keyboard arrangement exists) opens a modal that accepts `.gp{3,4,5,x}` and `.mid/.midi`, lists tracks with auto-flagging of piano-like ones, and imports the chosen track as a Keys arrangement.
- The wire format reuses guitar `string`/`fret` encoding (`pitch = string * 24 + fret`) — the piano plugin already decodes this — so no piano-plugin changes are required.

## How keyboard notes are encoded

```
{"t": 12.345, "s": 2, "f": 12, "sus": 0.5}
// MIDI pitch 60 (middle C) = string 2, fret 12
// Piano plugin: noteToMidi(s, f) = s*24 + f recovers the pitch
```

## Test plan

- [x] Open a `.sloppak` in the editor → all arrangements load with notes preserved.
- [x] Edit a note (drag in time / change fret), Save, reload → edit persists.
- [x] Round-trip Save with no edits preserves all fields including techniques (`palm_mute: true` survived).
- [x] Add a Keys arrangement from a GP file's piano track → arrangement appears, Save commits it, piano plugin renders it during playback.
- [x] Add a Keys arrangement from a `.mid` file → same flow works.
- [x] Remove an arrangement (e.g. one that was just added) → next Save drops it from the manifest and the orphaned JSON is removed from the zip.
- [x] PSARC files still load/save unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)