### PR TITLE
Allow authoring Keys arrangements from scratch in the editor

### DIFF
--- a/screen.html
+++ b/screen.html
@@ -282,6 +282,11 @@
                 class="w-full px-4 py-2 bg-indigo-700 hover:bg-indigo-600 rounded-lg text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed" disabled>
                 Import Keys Track
             </button>
+            <div class="text-center text-xs text-gray-600">— or —</div>
+            <button onclick="editorAddEmptyKeys()"
+                class="w-full px-4 py-2 bg-dark-600 hover:bg-dark-500 rounded-lg text-sm font-medium">
+                Start Empty (no source file)
+            </button>
             <div id="editor-add-keys-status" class="text-xs text-gray-500"></div>
         </div>
     </div>
@@ -291,10 +296,14 @@
 <div id="editor-add-note-dialog" class="hidden absolute z-50 bg-dark-700 border border-gray-700 rounded-lg shadow-xl p-3 w-48">
     <div class="text-xs text-gray-400 mb-2">Add Note</div>
     <div class="flex gap-2 mb-2">
-        <div class="flex-1">
+        <div id="editor-add-fret-col" class="flex-1">
             <label class="text-xs text-gray-500">Fret</label>
             <input id="editor-add-fret" type="number" min="0" max="24" value="0"
                 class="w-full bg-dark-800 border border-gray-700 rounded px-2 py-1 text-xs text-gray-300 outline-none">
+        </div>
+        <div id="editor-add-pitch-col" class="flex-1 hidden">
+            <label class="text-xs text-gray-500">Pitch</label>
+            <div id="editor-add-pitch-label" class="px-2 py-1 text-sm text-indigo-300 font-medium">C4</div>
         </div>
         <div class="flex-1">
             <label class="text-xs text-gray-500">Sustain</label>

--- a/screen.js
+++ b/screen.js
@@ -36,11 +36,9 @@ const PIANO_OCTAVE_COLORS = [
 ];
 let PIANO_LANE_H = 10;  // pixels per MIDI semitone
 let pianoRange = { lo: 36, hi: 96 }; // MIDI range, updated per arrangement
-// Names that should open in keys (piano-roll) editor mode. Keep this in
-// sync with the `+ Keys` button visibility test below — a name that's
-// considered "already a keys arrangement" must also open in keys mode,
-// otherwise sloppaks authored as "Piano"/"Keyboard"/"Synth" would render
-// as 6-string charts while the add-keys button is hidden.
+// Names that should open in keys (piano-roll) editor mode. Arrangements
+// named "Piano", "Keyboard", or "Synth" render as piano-roll charts rather
+// than 6-string guitar charts.
 const KEYS_PATTERN = /^(keys|piano|keyboard|synth)/i;
 
 // ════════════════════════════════════════════════════════════════════
@@ -124,7 +122,10 @@ function midiToFret(midi) { return midi % 24; }
 
 // Piano roll Y: higher MIDI = higher on screen (lower Y)
 function midiToY(midi) { return WAVEFORM_H + (pianoRange.hi - midi) * PIANO_LANE_H; }
-function yToMidi(y) { return pianoRange.hi - Math.floor((y - WAVEFORM_H) / PIANO_LANE_H); }
+function yToMidi(y) {
+    const m = pianoRange.hi - Math.floor((y - WAVEFORM_H) / PIANO_LANE_H);
+    return Math.max(pianoRange.lo, Math.min(pianoRange.hi, m));
+}
 
 // expandOnly=true preserves any wider current range (used during in-place
 // edits so adding a low note doesn't collapse the viewport and lose
@@ -156,8 +157,10 @@ function updatePianoRange(expandOnly = false) {
         nhi = Math.max(nhi, pianoRange.hi);
     }
     pianoRange = { lo: nlo, hi: nhi };
-    // Adjust lane height to fill available space nicely
-    PIANO_LANE_H = Math.max(6, Math.min(14, 350 / (nhi - nlo + 1)));
+    // Adjust lane height to fill available space nicely. Allow down to 4px
+    // so wide note ranges (many octaves) remain visible without overflowing
+    // the canvas wrapper.
+    PIANO_LANE_H = Math.max(4, Math.min(14, 350 / (nhi - nlo + 1)));
 }
 
 function snapTime(t) {

--- a/screen.js
+++ b/screen.js
@@ -126,7 +126,11 @@ function midiToFret(midi) { return midi % 24; }
 function midiToY(midi) { return WAVEFORM_H + (pianoRange.hi - midi) * PIANO_LANE_H; }
 function yToMidi(y) { return pianoRange.hi - Math.floor((y - WAVEFORM_H) / PIANO_LANE_H); }
 
-function updatePianoRange() {
+// expandOnly=true preserves any wider current range (used during in-place
+// edits so adding a low note doesn't collapse the viewport and lose
+// previously-clickable upper lanes). Load/import/arrangement-switch call
+// without it so the viewport snaps cleanly to the new arrangement.
+function updatePianoRange(expandOnly = false) {
     const nn = notes();
     let lo = 127, hi = 0;
     for (const n of nn) {
@@ -134,13 +138,25 @@ function updatePianoRange() {
         if (m < lo) lo = m;
         if (m > hi) hi = m;
     }
-    if (lo > hi) { lo = 48; hi = 84; }
+    if (lo > hi) {
+        // Empty arrangement: expose the full 88-key range so any starting
+        // pitch is clickable. Lanes are deliberately thin (~4px) to keep the
+        // viewport within ~352px — once a note is added the range snaps to
+        // the actual note range and lanes return to normal height.
+        pianoRange = { lo: 21, hi: 108, _fromEmpty: true };
+        PIANO_LANE_H = 4;
+        return;
+    }
     // Expand to octave boundaries with padding
-    lo = Math.max(0, Math.floor(lo / 12) * 12 - 6);
-    hi = Math.min(127, Math.ceil((hi + 1) / 12) * 12 + 5);
-    pianoRange = { lo, hi };
+    let nlo = Math.max(0, Math.floor(lo / 12) * 12 - 6);
+    let nhi = Math.min(127, Math.ceil((hi + 1) / 12) * 12 + 5);
+    if (expandOnly && pianoRange && !pianoRange._fromEmpty) {
+        nlo = Math.min(nlo, pianoRange.lo);
+        nhi = Math.max(nhi, pianoRange.hi);
+    }
+    pianoRange = { lo: nlo, hi: nhi };
     // Adjust lane height to fill available space nicely
-    PIANO_LANE_H = Math.max(6, Math.min(14, 350 / (hi - lo + 1)));
+    PIANO_LANE_H = Math.max(6, Math.min(14, 350 / (nhi - nlo + 1)));
 }
 
 function snapTime(t) {
@@ -631,9 +647,16 @@ function hitNoteEdge(mx, my) {
 
 class EditHistory {
     constructor() { this.undo = []; this.redo = []; }
-    exec(cmd) { cmd.exec(); this.undo.push(cmd); this.redo = []; this._ui(); }
-    doUndo() { if (!this.undo.length) return; const c = this.undo.pop(); c.rollback(); this.redo.push(c); this._ui(); draw(); }
-    doRedo() { if (!this.redo.length) return; const c = this.redo.pop(); c.exec(); this.undo.push(c); this._ui(); draw(); }
+    exec(cmd) { cmd.exec(); this.undo.push(cmd); this.redo = []; this._afterEdit(); this._ui(); }
+    doUndo() { if (!this.undo.length) return; const c = this.undo.pop(); c.rollback(); this.redo.push(c); this._afterEdit(); this._ui(); draw(); }
+    doRedo() { if (!this.redo.length) return; const c = this.redo.pop(); c.exec(); this.undo.push(c); this._afterEdit(); this._ui(); draw(); }
+    _afterEdit() {
+        // Keep the keys viewport in sync with the current note range so
+        // multi-octave authoring works without manual range control.
+        // expandOnly=true so adding a note outside the current viewport
+        // extends it instead of collapsing to the latest note's octave.
+        if (typeof isKeysMode === 'function' && isKeysMode()) updatePianoRange(true);
+    }
     _ui() {
         const u = document.getElementById('editor-undo');
         const r = document.getElementById('editor-redo');
@@ -1244,15 +1267,28 @@ function promptSlide(idx) {
 let addNoteData = null;
 
 function showAddNote(cx, cy, time, string, fret) {
-    addNoteData = { time, string };
+    const isKeys = isKeysMode();
+    addNoteData = { time, string, fret, isKeys };
     const dlg = document.getElementById('editor-add-note-dialog');
     dlg.style.left = cx + 'px';
     dlg.style.top = cy + 'px';
     dlg.classList.remove('hidden');
-    const inp = document.getElementById('editor-add-fret');
-    inp.value = fret != null ? String(fret) : '0';
-    inp.focus();
-    inp.select();
+
+    document.getElementById('editor-add-fret-col').classList.toggle('hidden', isKeys);
+    document.getElementById('editor-add-pitch-col').classList.toggle('hidden', !isKeys);
+
+    if (isKeys) {
+        const midi = noteToMidi(string, fret);
+        document.getElementById('editor-add-pitch-label').textContent = midiToNote(midi);
+        const sus = document.getElementById('editor-add-sustain');
+        sus.focus();
+        sus.select();
+    } else {
+        const inp = document.getElementById('editor-add-fret');
+        inp.value = fret != null ? String(fret) : '0';
+        inp.focus();
+        inp.select();
+    }
 }
 
 function hideAddNote() {
@@ -1262,7 +1298,9 @@ function hideAddNote() {
 
 window.editorConfirmAddNote = function() {
     if (!addNoteData) return;
-    const fret = Math.max(0, Math.min(24, parseInt(document.getElementById('editor-add-fret').value) || 0));
+    const fret = addNoteData.isKeys
+        ? addNoteData.fret
+        : Math.max(0, Math.min(24, parseInt(document.getElementById('editor-add-fret').value) || 0));
     const sustain = Math.max(0, parseFloat(document.getElementById('editor-add-sustain').value) || 0);
     const note = {
         time: addNoteData.time,
@@ -2707,6 +2745,60 @@ window.editorDoAddKeys = async () => {
     } catch (e) {
         statusEl.textContent = 'Failed: ' + e.message;
         goBtn.disabled = false;
+    }
+};
+
+function _uniqueKeysName() {
+    const taken = new Set(S.arrangements.map(a => (a.name || '').toLowerCase()));
+    if (!taken.has('keys')) return 'Keys';
+    for (let i = 2; i < 100; i++) if (!taken.has(`keys ${i}`)) return `Keys ${i}`;
+    return 'Keys';
+}
+
+let _addingEmptyKeys = false;
+
+window.editorAddEmptyKeys = async () => {
+    if (S.format !== 'sloppak' || !S.sessionId) return;
+    if (_addingEmptyKeys) return;
+    _addingEmptyKeys = true;
+    const statusEl = document.getElementById('editor-add-keys-status');
+    const arrangement = {
+        name: _uniqueKeysName(),
+        tuning: [0, 0, 0, 0, 0, 0],
+        capo: 0,
+        notes: [],
+        chords: [],
+        chord_templates: [],
+    };
+    try {
+        const resp = await fetch('/api/plugins/editor/add-arrangement', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ session_id: S.sessionId, arrangement }),
+        });
+        const data = await resp.json().catch(() => ({}));
+        if (!resp.ok || data.error) {
+            statusEl.textContent = 'Error registering arrangement: ' + (data.error || resp.status);
+            return;
+        }
+
+        S.arrangements.push(arrangement);
+        S.currentArr = S.arrangements.length - 1;
+        const sel = document.getElementById('editor-arrangement');
+        if (sel) sel.value = S.currentArr;
+
+        flattenChords();
+        if (typeof updatePianoRange === 'function') updatePianoRange();
+        updateArrangementSelector();
+        updateStatus();
+        draw();
+
+        editorHideAddKeysModal();
+        setStatus('Added empty Keys arrangement. Double-click the chart to add notes; save to commit.');
+    } catch (e) {
+        statusEl.textContent = 'Failed: ' + e.message;
+    } finally {
+        _addingEmptyKeys = false;
     }
 };
 

--- a/screen.js
+++ b/screen.js
@@ -132,7 +132,8 @@ function yToMidi(y) { return pianoRange.hi - Math.floor((y - WAVEFORM_H) / PIANO
 // without it so the viewport snaps cleanly to the new arrangement.
 function updatePianoRange(expandOnly = false) {
     const nn = notes();
-    let lo = 127, hi = 0;
+    // noteToMidi encodes up to string=5, fret=23 → max 143; match the drag-clamp ceiling.
+    let lo = 143, hi = 0;
     for (const n of nn) {
         const m = noteToMidi(n.string, n.fret);
         if (m < lo) lo = m;
@@ -147,9 +148,9 @@ function updatePianoRange(expandOnly = false) {
         PIANO_LANE_H = 4;
         return;
     }
-    // Expand to octave boundaries with padding
+    // Expand to octave boundaries with padding; ceiling matches drag-clamp max of 143.
     let nlo = Math.max(0, Math.floor(lo / 12) * 12 - 6);
-    let nhi = Math.min(127, Math.ceil((hi + 1) / 12) * 12 + 5);
+    let nhi = Math.min(143, Math.ceil((hi + 1) / 12) * 12 + 5);
     if (expandOnly && pianoRange && !pianoRange._fromEmpty) {
         nlo = Math.min(nlo, pianoRange.lo);
         nhi = Math.max(nhi, pianoRange.hi);
@@ -2746,10 +2747,13 @@ window.editorDoAddKeys = async () => {
 };
 
 function _uniqueKeysName() {
-    const taken = new Set(S.arrangements.map(a => (a.name || '').toLowerCase()));
+    const taken = new Set(S.arrangements.map(a => (a.name || '').trim().toLowerCase()));
     if (!taken.has('keys')) return 'Keys';
-    for (let i = 2; i < 100; i++) if (!taken.has(`keys ${i}`)) return `Keys ${i}`;
-    return 'Keys';
+    // The taken set has a finite number of entries, so a free slot is guaranteed
+    // within taken.size + 1 iterations; the +2 ceiling is a safety margin.
+    const limit = taken.size + 2;
+    for (let i = 2; i <= limit; i++) if (!taken.has(`keys ${i}`)) return `Keys ${i}`;
+    return `Keys ${Date.now()}`;
 }
 
 let _addingEmptyKeys = false;

--- a/screen.js
+++ b/screen.js
@@ -1524,13 +1524,10 @@ function updateArrangementSelector() {
         drumsBtn.classList.toggle('hidden', !S.sessionId || hasDrums);
     }
 
-    // Show "+ Keys" button on sloppak sessions when no keys arrangement exists yet.
-    // Use the same predicate as isKeysMode() so the set of names treated as
-    // existing keys charts is exactly the set that opens in keys editor mode.
-    const hasKeys = S.arrangements.some(a => KEYS_PATTERN.test(a.name || ''));
+    // Show "+ Keys" button on sloppak sessions; multiple Keys arrangements are allowed.
     const keysBtn = document.getElementById('editor-add-keys-btn');
     if (keysBtn) {
-        keysBtn.classList.toggle('hidden', !S.sessionId || S.format !== 'sloppak' || hasKeys);
+        keysBtn.classList.toggle('hidden', !S.sessionId || S.format !== 'sloppak');
     }
 
     // Show remove button when there are multiple arrangements


### PR DESCRIPTION
## Summary
- Adds a **Start Empty** path on the `+ Keys` modal so users can author a Keys arrangement without a source GP/MIDI file.
- Fixes the double-click add-note dialog in keys mode: it now honours the clicked pitch instead of dropping the fret and falling back to whatever the generic Fret input held.
- Keeps the keys viewport in sync with the current note range via an `EditHistory._afterEdit` hook with expand-only semantics, so multi-octave authoring extends the viewport without losing previously-clickable lanes; load/import/arrangement-switch still get a fresh recompute.
- Empty Keys default opens the full 88-key range at thin 4px lanes (~352px tall, fits laptop viewports) so any starting pitch is clickable; snaps to the actual note range on first add.

## Test plan
- [ ] Open editor on a sloppak → click `+ Keys` → modal shows file picker **and** `Start Empty (no source file)` with a `— or —` divider.
- [ ] Click **Start Empty** → modal closes → `Keys` arrangement appears in the switcher and is selected → piano-roll view renders with full 88-key range.
- [ ] Double-click any row → dialog shows `Pitch: <name>` (no Fret input) and Sustain focused → confirm → note lands on that row at the snapped click time.
- [ ] Subsequent double-clicks update the pitch label to match → confirm → notes land on the correct row.
- [ ] Add a low note (e.g. E2), then a high note (e.g. G6) → range expands to include both, lower lanes remain clickable.
- [ ] Ctrl-Z removes; Ctrl-Shift-Z restores.
- [ ] Save sloppak → reload → new Keys arrangement persists in `manifest.yaml` + `arrangements/keys.json`.
- [ ] Open the song in the player → notes render via the piano plugin.
- [ ] Switch to a guitar arrangement → double-click empty space → original Fret/Sustain dialog still appears unchanged.
- [ ] Existing GP/MIDI import via the same modal still works through the original track-picker flow.
- [ ] Click **Start Empty** twice → second arrangement is named `Keys 2`.
- [ ] Rapidly double-click **Start Empty** → only one arrangement is created (in-flight guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)