### PR TITLE
Live MIDI keyboard recording for Keys arrangements

### DIFF
--- a/screen.html
+++ b/screen.html
@@ -25,7 +25,7 @@
         <button id="editor-build-btn" onclick="editorBuild()" class="px-3 py-1 bg-purple-800 hover:bg-purple-700 rounded text-xs font-medium hidden">Build CDLC</button>
         <button id="editor-add-drums-btn" onclick="editorShowAddDrumsModal()" class="px-3 py-1 bg-red-900 hover:bg-red-800 rounded text-xs font-medium hidden">+ Drums</button>
         <button id="editor-add-keys-btn" onclick="editorShowAddKeysModal()" class="px-3 py-1 bg-indigo-900 hover:bg-indigo-800 rounded text-xs font-medium hidden">+ Keys</button>
-        <button id="editor-record-midi-btn" onclick="editorShowRecordMidiModal()" class="px-3 py-1 bg-rose-900 hover:bg-rose-800 rounded text-xs font-medium hidden" title="Record a Keys arrangement live from a MIDI keyboard (Chrome/Edge)">● Record</button>
+        <button id="editor-record-midi-btn" onclick="editorShowRecordMidiModal()" class="px-3 py-1 bg-rose-900 hover:bg-rose-800 rounded text-xs font-medium hidden disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-rose-900" title="Record a Keys arrangement live from a MIDI keyboard (Chrome/Edge)">● Record</button>
 
         <div class="h-4 w-px bg-gray-700"></div>
 

--- a/screen.html
+++ b/screen.html
@@ -25,6 +25,7 @@
         <button id="editor-build-btn" onclick="editorBuild()" class="px-3 py-1 bg-purple-800 hover:bg-purple-700 rounded text-xs font-medium hidden">Build CDLC</button>
         <button id="editor-add-drums-btn" onclick="editorShowAddDrumsModal()" class="px-3 py-1 bg-red-900 hover:bg-red-800 rounded text-xs font-medium hidden">+ Drums</button>
         <button id="editor-add-keys-btn" onclick="editorShowAddKeysModal()" class="px-3 py-1 bg-indigo-900 hover:bg-indigo-800 rounded text-xs font-medium hidden">+ Keys</button>
+        <button id="editor-record-midi-btn" onclick="editorShowRecordMidiModal()" class="px-3 py-1 bg-rose-900 hover:bg-rose-800 rounded text-xs font-medium hidden" title="Record a Keys arrangement live from a MIDI keyboard (Chrome/Edge)">● Record</button>
 
         <div class="h-4 w-px bg-gray-700"></div>
 
@@ -288,6 +289,50 @@
                 Start Empty (no source file)
             </button>
             <div id="editor-add-keys-status" class="text-xs text-gray-500"></div>
+        </div>
+    </div>
+</div>
+
+<!-- Record MIDI modal -->
+<div id="editor-record-midi-modal" class="hidden absolute inset-0 z-50 flex items-center justify-center" style="background:rgba(0,0,0,0.7)">
+    <div class="bg-dark-700 rounded-xl border border-gray-700 w-full max-w-md flex flex-col">
+        <div class="flex items-center justify-between px-4 py-3 border-b border-gray-700">
+            <span class="text-sm font-medium">Record Keys (live MIDI)</span>
+            <button onclick="editorHideRecordMidiModal()" class="text-gray-500 hover:text-white">&times;</button>
+        </div>
+        <div class="p-4 space-y-3">
+            <div id="editor-record-midi-setup" class="space-y-3">
+                <div>
+                    <label class="text-xs font-medium text-gray-400 mb-1 block">MIDI Device</label>
+                    <select id="editor-record-midi-device"
+                        class="w-full bg-dark-800 border border-gray-700 rounded px-2 py-1 text-xs text-gray-300 outline-none"></select>
+                    <p id="editor-record-midi-no-device" class="hidden text-[11px] text-rose-400 mt-1">No MIDI input detected — connect a keyboard and reopen.</p>
+                    <p id="editor-record-midi-no-webmidi" class="hidden text-[11px] text-rose-400 mt-1">Web MIDI not available in this browser — use Chrome or Edge.</p>
+                </div>
+                <div>
+                    <label class="text-xs font-medium text-gray-400 mb-1 block">Channel</label>
+                    <select id="editor-record-midi-channel"
+                        class="w-full bg-dark-800 border border-gray-700 rounded px-2 py-1 text-xs text-gray-300 outline-none">
+                        <option value="-1">All channels</option>
+                    </select>
+                </div>
+                <button onclick="editorStartRecordMidi()" id="editor-record-midi-start"
+                    class="w-full px-4 py-2 bg-rose-700 hover:bg-rose-600 rounded-lg text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed">
+                    Start Recording (audio will play)
+                </button>
+            </div>
+            <div id="editor-record-midi-active" class="hidden flex items-center justify-between gap-3">
+                <div class="flex items-center gap-2 text-sm">
+                    <span class="inline-block w-2.5 h-2.5 rounded-full bg-rose-500 animate-pulse"></span>
+                    <span>Recording…</span>
+                    <span id="editor-record-midi-count" class="text-gray-400">0 notes</span>
+                </div>
+                <button onclick="editorStopRecordMidi()"
+                    class="px-3 py-1.5 bg-dark-600 hover:bg-dark-500 rounded text-xs font-medium">
+                    Stop
+                </button>
+            </div>
+            <div id="editor-record-midi-status" class="text-xs text-gray-500"></div>
         </div>
     </div>
 </div>

--- a/screen.js
+++ b/screen.js
@@ -2414,6 +2414,10 @@ function init() {
 // ════════════════════════════════════════════════════════════════════
 
 window.editorRemoveArrangement = async () => {
+    if (_recState !== 'idle') {
+        setStatus('Cannot remove an arrangement while recording. Stop the take first.');
+        return;
+    }
     if (S.arrangements.length <= 1) return;
     const removeIdx = S.currentArr;
     const arr = S.arrangements[removeIdx];
@@ -2856,6 +2860,8 @@ const _recSustainOn = new Set();           // channels with CC64 pedal currently
 let _recNotes = [];                        // finalized {time,string,fret,sustain,techniques}
 let _recArrIdx = -1;                       // index of the in-progress Keys arrangement
 let ghostNotes = null;                     // alias of _recNotes while recording (for drawGhostNotes)
+let _recCountEl = null;                    // cached count DOM element (set at record-start)
+let _recCountLastMs = 0;                   // last timestamp _recCount updated the DOM
 
 function chartTimeNow() {
     // editorStartRecordMidi guards against !S.audioCtx, so this only runs
@@ -2983,8 +2989,10 @@ function _recFinalizeNote(pitch, onTime, offTime) {
 }
 
 function _recCount() {
-    const el = document.getElementById('editor-record-midi-count');
-    if (el) el.textContent = _recNotes.length + ' notes';
+    const now = performance.now();
+    if (now - _recCountLastMs < 80) return;   // throttle: at most once per ~80 ms
+    _recCountLastMs = now;
+    if (_recCountEl) _recCountEl.textContent = _recNotes.length + ' notes';
 }
 
 window.editorShowRecordMidiModal = async () => {
@@ -3096,6 +3104,8 @@ window.editorStartRecordMidi = () => {
     _recPending.clear();
     _recSustainOn.clear();
     _recNotes = [];
+    _recCountEl = document.getElementById('editor-record-midi-count');
+    _recCountLastMs = 0;  // reset throttle so the initial "0 notes" shows immediately
     _recCount();
     _recChannel = parseInt(chanSel.value);
     if (Number.isNaN(_recChannel)) _recChannel = -1;
@@ -3170,6 +3180,10 @@ window.editorStopRecordMidi = () => {
     _recNotes.sort((a, b) => a.time - b.time);
     const arr = S.arrangements[_recArrIdx];
     if (arr) arr.notes = _recNotes;
+
+    // Flush the final note count to the modal before hiding it.
+    _recCountLastMs = 0;
+    _recCount();
 
     // Restore focus to the recorded arrangement (user may have switched the
     // selector via keyboard / OS events that bypass the disabled flag) and

--- a/screen.js
+++ b/screen.js
@@ -2902,7 +2902,8 @@ function _recMidiUpdateDeviceList() {
     for (const inp of inputs) {
         const opt = document.createElement('option');
         opt.value = inp.id;
-        opt.textContent = inp.name;
+        const label = inp.name || inp.manufacturer || `MIDI Device (${inp.id})`;
+        opt.textContent = label;
         if (inp.id === saved) opt.selected = true;
         sel.appendChild(opt);
     }

--- a/screen.js
+++ b/screen.js
@@ -1408,6 +1408,7 @@ function playbackTick() {
             stopPlayback();
         }
         S.cursorTime = 0;
+        return; // stopPlayback() already cancelled rafId; don't re-schedule.
     }
 
     // Auto-scroll to follow cursor
@@ -3077,6 +3078,9 @@ window.editorStartRecordMidi = () => {
     flattenChords();
     if (typeof updatePianoRange === 'function') updatePianoRange();
     updateArrangementSelector();
+    // Lock the selector for the duration of the take so a mid-recording
+    // switch can't make Stop finalize into a stale arrangement index.
+    if (arrSel) arrSel.disabled = true;
 
     _recHeld.clear();
     _recPending.clear();
@@ -3156,6 +3160,16 @@ window.editorStopRecordMidi = () => {
     _recNotes.sort((a, b) => a.time - b.time);
     const arr = S.arrangements[_recArrIdx];
     if (arr) arr.notes = _recNotes;
+
+    // Restore focus to the recorded arrangement (user may have switched the
+    // selector via keyboard / OS events that bypass the disabled flag) and
+    // unlock the selector now that the take is final.
+    S.currentArr = _recArrIdx;
+    const arrSelStop = document.getElementById('editor-arrangement');
+    if (arrSelStop) {
+        arrSelStop.disabled = false;
+        arrSelStop.value = String(_recArrIdx);
+    }
 
     // Clear the ghost overlay BEFORE the redraw so the new notes don't
     // render twice (once as real notes, once as translucent ghosts).

--- a/screen.js
+++ b/screen.js
@@ -790,6 +790,10 @@ function onMouseDown(e) {
         return;
     }
 
+    // Block note editing while recording: mid-take edits to arr.notes would be
+    // silently overwritten by _recNotes when the take is finalized on Stop.
+    if (_recState === 'recording') return;
+
     // Check for sustain edge grab first
     const edgeIdx = hitNoteEdge(x, y);
     if (edgeIdx >= 0) {
@@ -985,6 +989,7 @@ function onMouseUp(e) {
 }
 
 function onDblClick(e) {
+    if (_recState === 'recording') return;  // block note addition during active take
     const { x, y } = getMousePos(e);
     const keysMode = isKeysMode();
     const laneBottom = keysMode
@@ -1100,6 +1105,7 @@ function onKeyDown(e) {
     }
 
     if (e.key === 'Delete' || e.key === 'Backspace') {
+        if (_recState === 'recording') return;  // block deletion during active take
         if (S.sel.size && !e.target.matches('input, select, textarea')) {
             e.preventDefault();
             S.history.exec(new DeleteNotesCmd([...S.sel]));
@@ -1110,11 +1116,13 @@ function onKeyDown(e) {
     }
 
     if ((e.ctrlKey || e.metaKey) && e.key === 'z') {
+        if (_recState === 'recording') return;  // block undo during active take
         e.preventDefault();
         editorUndo();
         return;
     }
     if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.shiftKey && e.key === 'Z'))) {
+        if (_recState === 'recording') return;  // block redo during active take
         e.preventDefault();
         editorRedo();
         return;
@@ -1149,6 +1157,7 @@ function onKeyDown(e) {
         }
     }
     if ((e.ctrlKey || e.metaKey) && e.key === 'v') {
+        if (_recState === 'recording') return;  // block paste during active take
         if (S.clipboard && S.clipboard.notes.length && !e.target.matches('input, select, textarea')) {
             e.preventDefault();
             const pasteTime = S.cursorTime;

--- a/screen.js
+++ b/screen.js
@@ -2935,12 +2935,12 @@ function _recMidiOnMessage(e) {
     const ch = status & 0x0F;
     if (_recChannel >= 0 && ch !== _recChannel) return;
     const cmd = status & 0xF0;
+    const note = data1;  // semantic alias: note number for on/off, cc number for B0 messages
 
     if (cmd === 0x90 && velocity > 0) {
         // Note on — push held entry (FIFO supports rapid retriggers).
         // Tag with `ch` so multi-channel layered/split keyboards in
         // "All channels" mode can pair note-offs with the correct take.
-        const note = data1;
         let q = _recHeld.get(note);
         if (!q) { q = []; _recHeld.set(note, q); }
         q.push({ onTime: chartTimeNow(), channel: ch });
@@ -2948,7 +2948,6 @@ function _recMidiOnMessage(e) {
         // Note off — match the oldest held entry from the same channel.
         // Without the channel match, two layered channels playing the same
         // pitch would close each other's notes in arbitrary order.
-        const note = data1;
         const q = _recHeld.get(note);
         if (!q || !q.length) return;
         const idx = q.findIndex(e => e.channel === ch);

--- a/screen.js
+++ b/screen.js
@@ -3165,10 +3165,10 @@ window.editorStopRecordMidi = () => {
     // selector via keyboard / OS events that bypass the disabled flag) and
     // unlock the selector now that the take is final.
     S.currentArr = _recArrIdx;
-    const arrSelStop = document.getElementById('editor-arrangement');
-    if (arrSelStop) {
-        arrSelStop.disabled = false;
-        arrSelStop.value = String(_recArrIdx);
+    const arrSel = document.getElementById('editor-arrangement');
+    if (arrSel) {
+        arrSel.disabled = false;
+        arrSel.value = String(_recArrIdx);
     }
 
     // Clear the ghost overlay BEFORE the redraw so the new notes don't

--- a/screen.js
+++ b/screen.js
@@ -289,6 +289,7 @@ function draw() {
     drawBeatBar(w);
     drawNotes(w);
     drawSelectionRect(w);
+    drawGhostNotes();
     drawCursor(w, h);
     drawLabels(w);
 
@@ -1398,7 +1399,14 @@ function playbackTick() {
     if (!S.playing) return;
     S.cursorTime = S.playStartTime + (S.audioCtx.currentTime - S.playStartWall);
     if (S.cursorTime >= S.duration) {
-        stopPlayback();
+        // If a live MIDI recording is active, finalize it at the song end
+        // before resetting the cursor — otherwise chartTimeNow() keeps
+        // advancing past S.duration and emits notes beyond the chart.
+        if (_recState === 'recording') {
+            editorStopRecordMidi();
+        } else {
+            stopPlayback();
+        }
         S.cursorTime = 0;
     }
 
@@ -1534,6 +1542,19 @@ function updateArrangementSelector() {
         keysBtn.classList.toggle('hidden', !S.sessionId || S.format !== 'sloppak');
     }
 
+    // Show "● Record" (live MIDI) button on sloppak sessions only — PSARC's
+    // add-arrangement path requires an xml_path we can't synthesize, and
+    // PSARC build silently drops extra arrangements anyway. Mirror the
+    // "+ Keys" gate exactly so users only see Record where it persists.
+    const recBtn = document.getElementById('editor-record-midi-btn');
+    if (recBtn) {
+        recBtn.classList.toggle('hidden', !S.sessionId || S.format !== 'sloppak');
+        if (!navigator.requestMIDIAccess) {
+            recBtn.disabled = true;
+            recBtn.title = 'Web MIDI not available — use Chrome or Edge.';
+        }
+    }
+
     // Show remove button when there are multiple arrangements
     const removeBtn = document.getElementById('editor-remove-arr-btn');
     if (removeBtn) {
@@ -1642,6 +1663,11 @@ function filterSongs(q) {
 
 async function saveCDLC() {
     if (!S.sessionId) return;
+    // If a live MIDI take is in flight, finalize it first so its notes
+    // get committed into S.arrangements[_recArrIdx] before we serialize.
+    // Without this, Save mid-recording would persist the new Keys
+    // arrangement with notes: [] and discard the take.
+    if (_recState === 'recording') editorStopRecordMidi();
     setStatus('Saving...');
 
     // Sloppak save sends the full S.arrangements snapshot, so every
@@ -1763,6 +1789,13 @@ window.editorSave = saveCDLC;
 window.editorUndo = () => S.history && S.history.doUndo();
 window.editorRedo = () => S.history && S.history.doRedo();
 window.editorTogglePlay = () => {
+    // Route stops through the recorder while a take is active so the
+    // spacebar (or any other transport caller) finalizes the recording
+    // cleanly instead of leaving _recState stuck in 'recording'.
+    if (_recState === 'recording') {
+        editorStopRecordMidi();
+        return;
+    }
     if (S.playing) stopPlayback(); else startPlayback();
 };
 window.editorZoom = (dir) => {
@@ -2805,6 +2838,357 @@ window.editorAddEmptyKeys = async () => {
         _addingEmptyKeys = false;
     }
 };
+
+// ════════════════════════════════════════════════════════════════════
+// Record Keys arrangement live from a MIDI keyboard (Web MIDI API)
+// ════════════════════════════════════════════════════════════════════
+
+let _recMidiAccess = null;
+let _recMidiInput = null;
+let _recState = 'idle';                    // idle | recording | finalizing
+let _recChannel = -1;                      // -1 = all, else 0..15
+const _recHeld = new Map();                // pitch -> [{onTime, channel}, ...] FIFO
+const _recPending = new Map();             // pitch -> [{onTime, channel}, ...] FIFO (pedal-deferred)
+const _recSustainOn = new Set();           // channels with CC64 pedal currently held
+let _recNotes = [];                        // finalized {time,string,fret,sustain,techniques}
+let _recArrIdx = -1;                       // index of the in-progress Keys arrangement
+let ghostNotes = null;                     // alias of _recNotes while recording (for drawGhostNotes)
+
+function chartTimeNow() {
+    // editorStartRecordMidi guards against !S.audioCtx, so this only runs
+    // during an active recording with a loaded audio context.
+    return S.playStartTime + (S.audioCtx.currentTime - S.playStartWall);
+}
+
+async function _recMidiInit() {
+    if (_recMidiAccess) return;
+    if (!navigator.requestMIDIAccess) return;
+    try {
+        _recMidiAccess = await navigator.requestMIDIAccess({ sysex: false });
+        _recMidiAccess.onstatechange = () => _recMidiUpdateDeviceList();
+    } catch (e) {
+        console.warn('[Editor] MIDI access denied:', e);
+    }
+}
+
+function _recMidiUpdateDeviceList() {
+    const sel = document.getElementById('editor-record-midi-device');
+    const noDevice = document.getElementById('editor-record-midi-no-device');
+    const startBtn = document.getElementById('editor-record-midi-start');
+    if (!sel) return;
+    const inputs = [];
+    if (_recMidiAccess) _recMidiAccess.inputs.forEach(inp => inputs.push(inp));
+
+    const saved = localStorage.getItem('editor.recordMidiDeviceId') || '';
+    // Build options with createElement so device-supplied id/name strings
+    // can't break out into HTML — Web MIDI metadata comes from the OS/USB
+    // descriptor and isn't safe to interpolate via innerHTML.
+    sel.replaceChildren();
+    for (const inp of inputs) {
+        const opt = document.createElement('option');
+        opt.value = inp.id;
+        opt.textContent = inp.name;
+        if (inp.id === saved) opt.selected = true;
+        sel.appendChild(opt);
+    }
+
+    const empty = !inputs.length;
+    if (noDevice) noDevice.classList.toggle('hidden', !empty);
+    if (startBtn) startBtn.disabled = empty;
+}
+
+function _recMidiConnect(id) {
+    if (_recMidiInput) _recMidiInput.onmidimessage = null;
+    _recMidiInput = null;
+    if (!_recMidiAccess) return;
+    _recMidiAccess.inputs.forEach(inp => {
+        if (inp.id === id) {
+            _recMidiInput = inp;
+            _recMidiInput.onmidimessage = _recMidiOnMessage;
+            localStorage.setItem('editor.recordMidiDeviceId', id);
+        }
+    });
+}
+
+function _recMidiOnMessage(e) {
+    if (_recState !== 'recording') return;
+    const [status, note, velocity] = e.data;
+    const ch = status & 0x0F;
+    if (_recChannel >= 0 && ch !== _recChannel) return;
+    const cmd = status & 0xF0;
+
+    if (cmd === 0x90 && velocity > 0) {
+        // Note on — push held entry (FIFO supports rapid retriggers).
+        // Tag with `ch` so multi-channel layered/split keyboards in
+        // "All channels" mode can pair note-offs with the correct take.
+        let q = _recHeld.get(note);
+        if (!q) { q = []; _recHeld.set(note, q); }
+        q.push({ onTime: chartTimeNow(), channel: ch });
+    } else if (cmd === 0x80 || (cmd === 0x90 && velocity === 0)) {
+        // Note off — match the oldest held entry from the same channel.
+        // Without the channel match, two layered channels playing the same
+        // pitch would close each other's notes in arbitrary order.
+        const q = _recHeld.get(note);
+        if (!q || !q.length) return;
+        const idx = q.findIndex(e => e.channel === ch);
+        if (idx < 0) return;
+        const [entry] = q.splice(idx, 1);
+        if (!q.length) _recHeld.delete(note);
+        if (_recSustainOn.has(ch)) {
+            let p = _recPending.get(note);
+            if (!p) { p = []; _recPending.set(note, p); }
+            p.push(entry);
+        } else {
+            _recFinalizeNote(note, entry.onTime, chartTimeNow());
+        }
+    } else if (cmd === 0xB0 && note === 64) {
+        // CC64 sustain pedal — per-channel state so layered/split keyboards
+        // that emit CC64 on multiple channels don't cross-flush takes.
+        if (velocity >= 64) {
+            _recSustainOn.add(ch);
+        } else {
+            _recSustainOn.delete(ch);
+            const off = chartTimeNow();
+            for (const [pitch, queue] of _recPending) {
+                const remaining = [];
+                for (const entry of queue) {
+                    if (entry.channel === ch) {
+                        _recFinalizeNote(pitch, entry.onTime, off);
+                    } else {
+                        remaining.push(entry);
+                    }
+                }
+                if (remaining.length) _recPending.set(pitch, remaining);
+                else _recPending.delete(pitch);
+            }
+        }
+    }
+}
+
+function _recFinalizeNote(pitch, onTime, offTime) {
+    const sustain = Math.max(0, offTime - onTime);
+    _recNotes.push({
+        time: onTime,
+        string: Math.floor(pitch / 24),
+        fret: pitch % 24,
+        sustain: sustain < 0.05 ? 0 : sustain,
+        techniques: {},
+    });
+    _recCount();
+}
+
+function _recCount() {
+    const el = document.getElementById('editor-record-midi-count');
+    if (el) el.textContent = _recNotes.length + ' notes';
+}
+
+window.editorShowRecordMidiModal = async () => {
+    if (!S.sessionId) return;
+    const modal = document.getElementById('editor-record-midi-modal');
+    const setup = document.getElementById('editor-record-midi-setup');
+    const active = document.getElementById('editor-record-midi-active');
+    const status = document.getElementById('editor-record-midi-status');
+    const noWebMidi = document.getElementById('editor-record-midi-no-webmidi');
+    const startBtn = document.getElementById('editor-record-midi-start');
+    const chanSel = document.getElementById('editor-record-midi-channel');
+
+    setup.classList.remove('hidden');
+    active.classList.add('hidden');
+    status.textContent = '';
+
+    // Populate channel dropdown 1..16 once.
+    if (chanSel.options.length === 1) {
+        for (let i = 1; i <= 16; i++) {
+            const opt = document.createElement('option');
+            opt.value = String(i - 1);
+            opt.textContent = String(i);
+            chanSel.appendChild(opt);
+        }
+    }
+
+    if (!navigator.requestMIDIAccess) {
+        if (noWebMidi) noWebMidi.classList.remove('hidden');
+        if (startBtn) startBtn.disabled = true;
+    } else {
+        if (noWebMidi) noWebMidi.classList.add('hidden');
+        await _recMidiInit();
+        _recMidiUpdateDeviceList();
+    }
+
+    modal.classList.remove('hidden');
+};
+
+window.editorHideRecordMidiModal = () => {
+    // Refuse to close while a take is active — explicit Stop is required.
+    if (_recState !== 'idle') return;
+    document.getElementById('editor-record-midi-modal').classList.add('hidden');
+};
+
+window.editorStartRecordMidi = () => {
+    if (_recState !== 'idle') return;
+    const sel = document.getElementById('editor-record-midi-device');
+    const chanSel = document.getElementById('editor-record-midi-channel');
+    const status = document.getElementById('editor-record-midi-status');
+    const setup = document.getElementById('editor-record-midi-setup');
+    const active = document.getElementById('editor-record-midi-active');
+    if (S.format !== 'sloppak' || !S.sessionId) {
+        status.textContent = 'Recording requires a sloppak editing session.';
+        return;
+    }
+    if (!S.audioBuffer || !S.audioCtx) {
+        status.textContent = 'Audio not loaded — cannot derive note timing.';
+        return;
+    }
+    if (!sel || !sel.value) {
+        status.textContent = 'Select a MIDI device first.';
+        return;
+    }
+    _recMidiConnect(sel.value);
+    if (!_recMidiInput) {
+        status.textContent = 'Failed to connect to MIDI device.';
+        return;
+    }
+
+    // Splice + start playback synchronously inside the click handler:
+    //   (a) Chrome/Edge autoplay policy requires the AudioContext.resume()
+    //       inside startPlayback() to fire during the user-gesture grace
+    //       period — an awaited fetch would expire it and the transport
+    //       would never advance, putting every captured note at t=0.
+    //   (b) Punch-in (Record while already playing) must arm at the exact
+    //       playhead the user clicked from, not wherever audio drifted to
+    //       during a network round-trip.
+    // The /add-arrangement POST is fired-and-forgotten — for sloppak it's
+    // a no-op acknowledgement, and saving the session commits whatever
+    // is in S.arrangements regardless.
+    const arrangement = {
+        name: _uniqueKeysName(),
+        tuning: [0, 0, 0, 0, 0, 0],
+        capo: 0,
+        notes: [],
+        chords: [],
+        chord_templates: [],
+    };
+
+    S.arrangements.push(arrangement);
+    S.currentArr = S.arrangements.length - 1;
+    _recArrIdx = S.currentArr;
+    const arrSel = document.getElementById('editor-arrangement');
+    if (arrSel) arrSel.value = S.currentArr;
+    flattenChords();
+    if (typeof updatePianoRange === 'function') updatePianoRange();
+    updateArrangementSelector();
+
+    _recHeld.clear();
+    _recPending.clear();
+    _recSustainOn.clear();
+    _recNotes = [];
+    _recCount();
+    _recChannel = parseInt(chanSel.value);
+    if (Number.isNaN(_recChannel)) _recChannel = -1;
+
+    setup.classList.add('hidden');
+    active.classList.remove('hidden');
+    status.textContent = '';
+
+    ghostNotes = _recNotes;
+    _recState = 'recording';
+    // Restart cleanly if a playback is already running — startPlayback()
+    // allocates a fresh AudioBufferSourceNode and overwrites S.audioSource,
+    // which would otherwise orphan the existing source and desync stop.
+    // Refresh S.cursorTime from chartTimeNow() before the restart so
+    // punch-in resumes from the actual audio position, not the last
+    // playbackTick() snapshot (which can lag on throttled/slow frames).
+    if (S.playing) {
+        S.cursorTime = chartTimeNow();
+        stopPlayback();
+    }
+    startPlayback();
+
+    // Reliable end-of-song finalize: rAF (playbackTick) can be throttled
+    // or paused in backgrounded tabs and miss the EOF clamp, leaving
+    // _recState='recording' after audio actually ends. AudioBufferSourceNode's
+    // onended fires regardless of tab visibility. The state guard inside
+    // also makes this a no-op when stopPlayback() triggers onended via
+    // explicit Stop / spacebar — those paths set _recState='finalizing'
+    // before audioSource.stop() runs.
+    if (S.audioSource) {
+        S.audioSource.onended = () => {
+            if (_recState === 'recording') editorStopRecordMidi();
+        };
+    }
+
+    fetch('/api/plugins/editor/add-arrangement', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ session_id: S.sessionId, arrangement }),
+    }).catch(e => console.warn('[Editor] add-arrangement registration failed:', e));
+};
+
+window.editorStopRecordMidi = () => {
+    if (_recState !== 'recording') return;
+    _recState = 'finalizing';
+
+    // Capture stop-time before stopping audio so the chart-time formula
+    // still reads the in-flight playhead. Clamp to S.duration: when this
+    // path is reached via the EOF branch in playbackTick, chartTimeNow()
+    // has already crossed the song boundary, and any held/pedal-deferred
+    // notes would otherwise be finalized past the chart length.
+    const stopTime = Math.min(chartTimeNow(), S.duration || Infinity);
+    stopPlayback();
+
+    // Cap any still-held notes (key never released).
+    for (const [pitch, queue] of _recHeld) {
+        for (const { onTime } of queue) _recFinalizeNote(pitch, onTime, stopTime);
+    }
+    _recHeld.clear();
+    // Cap any pedal-deferred notes (sustain still down at stop).
+    for (const [pitch, queue] of _recPending) {
+        for (const { onTime } of queue) _recFinalizeNote(pitch, onTime, stopTime);
+    }
+    _recPending.clear();
+    _recSustainOn.clear();
+
+    if (_recMidiInput) _recMidiInput.onmidimessage = null;
+
+    // Populate the target arrangement registered at Start time. No second
+    // POST: the arrangement was already registered with the backend, so
+    // the splice is purely an in-memory note swap.
+    _recNotes.sort((a, b) => a.time - b.time);
+    const arr = S.arrangements[_recArrIdx];
+    if (arr) arr.notes = _recNotes;
+
+    // Clear the ghost overlay BEFORE the redraw so the new notes don't
+    // render twice (once as real notes, once as translucent ghosts).
+    ghostNotes = null;
+    _recState = 'idle';
+
+    flattenChords();
+    if (typeof updatePianoRange === 'function') updatePianoRange();
+    updateArrangementSelector();
+    updateStatus();
+    draw();
+
+    document.getElementById('editor-record-midi-modal').classList.add('hidden');
+    const n = arr ? arr.notes.length : 0;
+    setStatus(n
+        ? `Recorded Keys arrangement (${n} notes). Save to commit.`
+        : 'Stopped — no notes captured. The empty Keys arrangement is in the switcher.');
+};
+
+function drawGhostNotes() {
+    if (!ghostNotes || !ghostNotes.length || !isKeysMode()) return;
+    ctx.save();
+    ctx.globalAlpha = 0.45;
+    ctx.fillStyle = '#f43f5e';   // rose-500 — echoes the Record button
+    for (const n of ghostNotes) {
+        const midi = noteToMidi(n.string, n.fret);
+        const x = timeToX(n.time);
+        const y = midiToY(midi);
+        const w = Math.max(2, (n.sustain || 0) * S.zoom);
+        ctx.fillRect(x, y, w + 2, Math.max(2, PIANO_LANE_H - 1));
+    }
+    ctx.restore();
+}
 
 // Run init after DOM is ready
 if (document.getElementById('editor-canvas')) {

--- a/screen.js
+++ b/screen.js
@@ -1408,6 +1408,8 @@ function playbackTick() {
             stopPlayback();
         }
         S.cursorTime = 0;
+        updateTimeDisplay(); // reflect the reset immediately before returning
+        draw();
         return; // stopPlayback() already cancelled rafId; don't re-schedule.
     }
 
@@ -2862,13 +2864,15 @@ function chartTimeNow() {
 }
 
 async function _recMidiInit() {
-    if (_recMidiAccess) return;
-    if (!navigator.requestMIDIAccess) return;
+    if (_recMidiAccess) return true;
+    if (!navigator.requestMIDIAccess) return true;
     try {
         _recMidiAccess = await navigator.requestMIDIAccess({ sysex: false });
         _recMidiAccess.onstatechange = () => _recMidiUpdateDeviceList();
+        return true;
     } catch (e) {
         console.warn('[Editor] MIDI access denied:', e);
+        return false;
     }
 }
 
@@ -3012,8 +3016,14 @@ window.editorShowRecordMidiModal = async () => {
         if (startBtn) startBtn.disabled = true;
     } else {
         if (noWebMidi) noWebMidi.classList.add('hidden');
-        await _recMidiInit();
-        _recMidiUpdateDeviceList();
+        const granted = await _recMidiInit();
+        if (!granted) {
+            status.textContent = 'MIDI access denied — grant permission in browser settings and reopen.';
+            if (startBtn) startBtn.disabled = true;
+        } else {
+            status.textContent = '';
+            _recMidiUpdateDeviceList();
+        }
     }
 
     modal.classList.remove('hidden');

--- a/screen.js
+++ b/screen.js
@@ -1555,6 +1555,9 @@ function updateArrangementSelector() {
         if (!navigator.requestMIDIAccess) {
             recBtn.disabled = true;
             recBtn.title = 'Web MIDI not available — use Chrome or Edge.';
+        } else {
+            recBtn.disabled = false;
+            recBtn.title = 'Record a Keys arrangement live from a MIDI keyboard (Chrome/Edge)';
         }
     }
 
@@ -3161,6 +3164,15 @@ window.editorStopRecordMidi = () => {
     const stopTime = Math.min(chartTimeNow(), S.duration || Infinity);
     stopPlayback();
 
+    // When the take finalized at EOF (e.g. via audioSource.onended in a
+    // backgrounded tab where playbackTick was throttled), playbackTick's
+    // cursor-reset branch never ran. Reset here so the next playback
+    // starts from 0, not from a stale end-of-song position.
+    if (S.duration && stopTime >= S.duration) {
+        S.cursorTime = 0;
+        if (typeof updateTimeDisplay === 'function') updateTimeDisplay();
+    }
+
     // Cap any still-held notes (key never released).
     for (const [pitch, queue] of _recHeld) {
         for (const { onTime } of queue) _recFinalizeNote(pitch, onTime, stopTime);
@@ -3216,15 +3228,19 @@ window.editorStopRecordMidi = () => {
 
 function drawGhostNotes() {
     if (!ghostNotes || !ghostNotes.length || !isKeysMode()) return;
+    const w = canvas.width / DPR;
+    const st = S.scrollX - 2;
+    const et = S.scrollX + (w - LABEL_W) / S.zoom + 2;
     ctx.save();
     ctx.globalAlpha = 0.45;
     ctx.fillStyle = '#f43f5e';   // rose-500 — echoes the Record button
     for (const n of ghostNotes) {
+        if (n.time + (n.sustain || 0) < st || n.time > et) continue;
         const midi = noteToMidi(n.string, n.fret);
         const x = timeToX(n.time);
         const y = midiToY(midi);
-        const w = Math.max(2, (n.sustain || 0) * S.zoom);
-        ctx.fillRect(x, y, w + 2, Math.max(2, PIANO_LANE_H - 1));
+        const nw = Math.max(2, (n.sustain || 0) * S.zoom);
+        ctx.fillRect(x, y, nw + 2, Math.max(2, PIANO_LANE_H - 1));
     }
     ctx.restore();
 }

--- a/screen.js
+++ b/screen.js
@@ -2865,7 +2865,7 @@ function chartTimeNow() {
 
 async function _recMidiInit() {
     if (_recMidiAccess) return true;
-    if (!navigator.requestMIDIAccess) return true;
+    if (!navigator.requestMIDIAccess) return false;
     try {
         _recMidiAccess = await navigator.requestMIDIAccess({ sysex: false });
         _recMidiAccess.onstatechange = () => _recMidiUpdateDeviceList();
@@ -3018,7 +3018,7 @@ window.editorShowRecordMidiModal = async () => {
         if (noWebMidi) noWebMidi.classList.add('hidden');
         const granted = await _recMidiInit();
         if (!granted) {
-            status.textContent = 'MIDI access denied — grant permission in browser settings and reopen.';
+            status.textContent = 'MIDI access denied — grant permission in browser settings and reload this page.';
             if (startBtn) startBtn.disabled = true;
         } else {
             status.textContent = '';

--- a/screen.js
+++ b/screen.js
@@ -2862,6 +2862,7 @@ let _recArrIdx = -1;                       // index of the in-progress Keys arra
 let ghostNotes = null;                     // alias of _recNotes while recording (for drawGhostNotes)
 let _recCountEl = null;                    // cached count DOM element (set at record-start)
 let _recCountLastMs = 0;                   // last timestamp _recCount updated the DOM
+const REC_COUNT_THROTTLE_MS = 80;          // max DOM update rate for the note counter
 
 function chartTimeNow() {
     // editorStartRecordMidi guards against !S.audioCtx, so this only runs
@@ -2990,7 +2991,7 @@ function _recFinalizeNote(pitch, onTime, offTime) {
 
 function _recCount() {
     const now = performance.now();
-    if (now - _recCountLastMs < 80) return;   // throttle: at most once per ~80 ms
+    if (now - _recCountLastMs < REC_COUNT_THROTTLE_MS) return;   // throttle DOM writes
     _recCountLastMs = now;
     if (_recCountEl) _recCountEl.textContent = _recNotes.length + ' notes';
 }

--- a/screen.js
+++ b/screen.js
@@ -780,6 +780,9 @@ function onMouseDown(e) {
 
     // Left button
     if (y < WAVEFORM_H) {
+        // Block waveform seek while recording: restarting the AudioBufferSourceNode
+        // would fire onended and prematurely finalize the take.
+        if (_recState === 'recording') return;
         // Click on waveform = set cursor
         S.cursorTime = Math.max(0, xToTime(x));
         if (S.playing) { stopPlayback(); startPlayback(); }
@@ -2928,7 +2931,7 @@ function _recMidiConnect(id) {
 
 function _recMidiOnMessage(e) {
     if (_recState !== 'recording') return;
-    const [status, note, velocity] = e.data;
+    const [status, data1, velocity] = e.data;
     const ch = status & 0x0F;
     if (_recChannel >= 0 && ch !== _recChannel) return;
     const cmd = status & 0xF0;
@@ -2937,6 +2940,7 @@ function _recMidiOnMessage(e) {
         // Note on — push held entry (FIFO supports rapid retriggers).
         // Tag with `ch` so multi-channel layered/split keyboards in
         // "All channels" mode can pair note-offs with the correct take.
+        const note = data1;
         let q = _recHeld.get(note);
         if (!q) { q = []; _recHeld.set(note, q); }
         q.push({ onTime: chartTimeNow(), channel: ch });
@@ -2944,6 +2948,7 @@ function _recMidiOnMessage(e) {
         // Note off — match the oldest held entry from the same channel.
         // Without the channel match, two layered channels playing the same
         // pitch would close each other's notes in arbitrary order.
+        const note = data1;
         const q = _recHeld.get(note);
         if (!q || !q.length) return;
         const idx = q.findIndex(e => e.channel === ch);
@@ -2957,7 +2962,7 @@ function _recMidiOnMessage(e) {
         } else {
             _recFinalizeNote(note, entry.onTime, chartTimeNow());
         }
-    } else if (cmd === 0xB0 && note === 64) {
+    } else if (cmd === 0xB0 && data1 === 64) {
         // CC64 sustain pedal — per-channel state so layered/split keyboards
         // that emit CC64 on multiple channels don't cross-flush takes.
         if (velocity >= 64) {

--- a/screen.js
+++ b/screen.js
@@ -1104,8 +1104,13 @@ function onKeyDown(e) {
         return;
     }
 
+    // Block all note-mutating shortcuts while a take is active so mid-take
+    // edits can't be silently overwritten when arr.notes = _recNotes on Stop.
+    // Spacebar (above) is still allowed because it routes to editorTogglePlay
+    // → editorStopRecordMidi, which cleanly finalizes the take.
+    if (_recState === 'recording') return;
+
     if (e.key === 'Delete' || e.key === 'Backspace') {
-        if (_recState === 'recording') return;  // block deletion during active take
         if (S.sel.size && !e.target.matches('input, select, textarea')) {
             e.preventDefault();
             S.history.exec(new DeleteNotesCmd([...S.sel]));
@@ -1116,13 +1121,11 @@ function onKeyDown(e) {
     }
 
     if ((e.ctrlKey || e.metaKey) && e.key === 'z') {
-        if (_recState === 'recording') return;  // block undo during active take
         e.preventDefault();
         editorUndo();
         return;
     }
     if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.shiftKey && e.key === 'Z'))) {
-        if (_recState === 'recording') return;  // block redo during active take
         e.preventDefault();
         editorRedo();
         return;
@@ -1157,7 +1160,6 @@ function onKeyDown(e) {
         }
     }
     if ((e.ctrlKey || e.metaKey) && e.key === 'v') {
-        if (_recState === 'recording') return;  // block paste during active take
         if (S.clipboard && S.clipboard.notes.length && !e.target.matches('input, select, textarea')) {
             e.preventDefault();
             const pasteTime = S.cursorTime;

--- a/screen.js
+++ b/screen.js
@@ -3170,7 +3170,7 @@ window.editorStopRecordMidi = () => {
     // starts from 0, not from a stale end-of-song position.
     if (S.duration && stopTime >= S.duration) {
         S.cursorTime = 0;
-        if (typeof updateTimeDisplay === 'function') updateTimeDisplay();
+        updateTimeDisplay();
     }
 
     // Cap any still-held notes (key never released).


### PR DESCRIPTION
## Summary
- Adds a **● Record** button alongside `+ Keys` / `+ Drums`. The user picks a connected MIDI keyboard, hits **Start Recording**, plays along with the song's audio, and on **Stop** the captured notes appear as a brand-new Keys arrangement in the editor's switcher — ready to save into the sloppak.
- Web MIDI plumbing mirrors `plugins/piano` (init / device list / message handler) with FIFO held-note tracking, **per-channel** CC64 sustain pedal state, and channel filtering (incl. all-channels mode tagging each held entry with its source channel so layered/split keyboards don't cross-close notes).
- Sloppak-only and audio-required gate, mirroring `+ Keys`. Empty arrangement is spliced + playback started **synchronously** inside the click handler so Chrome/Edge autoplay policy lets `AudioContext.resume()` run during the user-gesture grace period; punch-in arms at the exact playhead. `/add-arrangement` is fired-and-forgotten in the background — for sloppak it's a no-op acknowledgement and saving commits `S.arrangements` regardless.
- `audioSource.onended` drives EOF finalization so backgrounded tabs with throttled `requestAnimationFrame` still get a clean stop. Spacebar `editorTogglePlay` and `saveCDLC` route through `editorStopRecordMidi` when a take is active to prevent stuck `'recording'` state and empty-arrangement saves.
- Live ghost overlay (`drawGhostNotes`, low-alpha rose bars) draws captured notes on the new Keys arrangement's piano-roll lanes; cleared before the post-stop redraw so notes don't double-render.
- Device names/ids inserted via `createElement` + `textContent` (Web MIDI metadata comes from OS/USB descriptors and isn't safe to interpolate via `innerHTML`).

## Out-of-scope follow-ups (filed)
- #3 — 4-beat count-in before audio start
- #4 — capture velocity (requires sloppak wire-format change)
- #5 — Quantize 1/16 (and other grids)
- #6 — Punch-in / Punch-out
- #7 — Overdub onto an existing Keys arrangement
- #8 — Multi-track session
- #9 — Audible metronome click
- #10 — Export captured arrangement as a .mid file

Firefox is permanently disabled (no Web MIDI support) — button shown disabled with a tooltip.

## Test plan
- [ ] Open editor on a `.sloppak` in Chrome. Plug in a MIDI keyboard. Click **● Record** → modal opens → device populated.
- [ ] Click **Start Recording** → modal collapses to active strip → audio plays → press a few keys → use sustain pedal across one release → click **Stop**. New `Keys` arrangement appears in switcher and is auto-selected.
- [ ] Notes visible in piano-roll at the chart times played; pedal-held note has expected longer `sustain`. Status bar count matches captured notes.
- [ ] **Save** → reload sloppak → recorded arrangement persists in `manifest.yaml` + `arrangements/keys*.json` with short-name wire format.
- [ ] Open the song in the player → switch to recorded Keys arrangement → piano plugin renders it during playback.
- [ ] Record while audio is **already playing** (punch-in) → take begins at the actual playhead, not from t=0.
- [ ] Click **Save** mid-recording → take is finalized first; saved arrangement contains the notes.
- [ ] Hit **Spacebar** mid-recording → take finalizes cleanly (no stuck recording state).
- [ ] Let recording run to song end → recorder auto-finalizes at EOF; cursor resets to 0 so next play works.
- [ ] Set channel filter to `2` on a keyboard transmitting on channel 1 → no notes captured.
- [ ] Play a fast trill (rapid retriggers of the same pitch) → each retrigger lands as a separate note.
- [ ] Open editor in Firefox → Record button disabled with tooltip about Web MIDI.
- [ ] Existing `+ Keys` (file import + Start Empty) and `+ Drums` flows still work.
- [ ] Codex `--base main` returned 0 issues from `plugins/editor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)