### PR TITLE
feat: expose sessions dict and track last_touched for demo janitor

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -21,6 +21,9 @@ from fastapi.responses import FileResponse, JSONResponse
 import yaml
 
 
+_sessions = None
+
+
 def setup(app, context):
     config_dir = context["config_dir"]
     get_dlc_dir = context["get_dlc_dir"]
@@ -114,8 +117,8 @@ def setup(app, context):
     # Active editing sessions: session_id -> {dir, audio_file, filename, song_data}
     sessions = {}
 
-    import sys as _sys
-    _sys.modules[__name__]._sessions = sessions
+    global _sessions
+    _sessions = sessions
 
     def _arrangement_id(name: str, used: set) -> str:
         """Map an arrangement name to a stable filesystem-safe id, avoiding

--- a/routes.py
+++ b/routes.py
@@ -114,6 +114,9 @@ def setup(app, context):
     # Active editing sessions: session_id -> {dir, audio_file, filename, song_data}
     sessions = {}
 
+    import sys as _sys
+    _sys.modules[__name__]._sessions = sessions
+
     def _arrangement_id(name: str, used: set) -> str:
         """Map an arrangement name to a stable filesystem-safe id, avoiding
         collisions (suffix counter starts at 2: bass, bass2, bass3, ...)."""
@@ -432,6 +435,7 @@ def setup(app, context):
             "xml_files": xml_files,
             "format": "sloppak" if is_sloppak else "psarc",
             "sloppak_state": sloppak_state,
+            "last_touched": time.time(),
         }
         result["session_id"] = session_id
         return result
@@ -444,6 +448,7 @@ def setup(app, context):
         session = sessions.get(session_id)
         if not session:
             return JSONResponse({"error": "No active session"}, 400)
+        session["last_touched"] = time.time()
 
         raw_arr_idx = data.get("arrangement_index")
         if raw_arr_idx is None:
@@ -1068,6 +1073,7 @@ def setup(app, context):
                 "title": title, "artist": artist,
                 "album": album, "year": year,
             },
+            "last_touched": time.time(),
         }
         result["session_id"] = session_id
         result["create_mode"] = True
@@ -1337,6 +1343,7 @@ def setup(app, context):
         session = sessions.get(session_id)
         if not session:
             return JSONResponse({"error": "No active session"}, 400)
+        session["last_touched"] = time.time()
 
         raw_idx = data.get("arrangement_index")
         if raw_idx is None:
@@ -1398,6 +1405,7 @@ def setup(app, context):
         session = sessions.get(session_id)
         if not session:
             return JSONResponse({"error": "No active session"}, 400)
+        session["last_touched"] = time.time()
 
         arrangement = data.get("arrangement")
         xml_path = data.get("xml_path", "")
@@ -1434,6 +1442,7 @@ def setup(app, context):
         session = sessions.get(session_id)
         if not session or not session.get("create_mode"):
             return JSONResponse({"error": "No active create session"}, 400)
+        session["last_touched"] = time.time()
 
         arrangements_data = data.get("arrangements", [])
         beats = data.get("beats", [])


### PR DESCRIPTION
## Summary

- Exposes `sessions` dict at module level as `_sessions` so the slopsmith core's demo-mode janitor can sweep stale sessions without importing plugin internals
- Adds `"last_touched": time.time()` on both session creation paths (file load and create-mode)
- Updates `last_touched` on every route that accesses an existing session: `save`, `remove-arrangement`, `add-arrangement`, `build`

Companion to byrongamatos/slopsmith#148.

## Test plan

- [ ] Load a song in the editor — session appears in `_sessions` with a `last_touched` timestamp
- [ ] Interact with the editor (save attempt, add/remove arrangement) — `last_touched` advances
- [ ] Simulate janitor: sessions with `last_touched` older than 24h are removed, recent ones survive

🤖 Generated with [Claude Code](https://claude.com/claude-code)